### PR TITLE
fixes TS1261 errors on build

### DIFF
--- a/packages/geom-area/src/geomArea.tsx
+++ b/packages/geom-area/src/geomArea.tsx
@@ -36,7 +36,7 @@ import {
 import { min, max, sum, extent } from 'd3-array'
 import { useAtom } from 'jotai'
 import type { GeomAes, StackedArea } from './types'
-import { LineMarker, Tooltip } from './tooltip'
+import { LineMarker, Tooltip } from './Tooltip'
 
 export interface GeomAreaProps extends SVGAttributes<SVGPathElement> {
   data?: unknown[]

--- a/packages/geom-label/src/geomLabel.tsx
+++ b/packages/geom-label/src/geomLabel.tsx
@@ -27,7 +27,7 @@ import {
   PageVisibility,
 } from '@graphique/graphique'
 import { type GeomAes } from './types'
-import { Tooltip } from './tooltip'
+import { Tooltip } from './Tooltip'
 
 export interface LabelProps extends SVGAttributes<SVGTextElement> {
   data?: unknown[]
@@ -106,7 +106,7 @@ const GeomLabel = ({
   const getLabel = useMemo(() => {
     if (!geomAes?.label && !label)
       throw new Error('You need to provide a `label` or map a `label` in `aes` in order to use GeomLabel')
-      
+
     return geomAes?.label
   }, [geomAes, label])
 
@@ -360,9 +360,9 @@ const GeomLabel = ({
                         styles = focusedStyles
                       if (focusedKeys?.length > 0 && !focusedKeys.includes(key))
                         styles = unfocusedStyles
-                      
+
                       const nodeX = x(nodeData) ?? 0
-                      
+
                       return (
                         <text
                           key={key}

--- a/packages/geom-line/src/geomLine.tsx
+++ b/packages/geom-line/src/geomLine.tsx
@@ -27,7 +27,7 @@ import { interpolatePath } from 'd3-interpolate-path'
 import { line, CurveFactory, curveLinear } from 'd3-shape'
 import { scaleOrdinal } from 'd3-scale'
 import { useAtom } from 'jotai'
-import { LineMarker, Tooltip } from './tooltip'
+import { LineMarker, Tooltip } from './Tooltip'
 import { type GeomAes } from './types'
 
 export interface LineProps extends SVGAttributes<SVGPathElement> {

--- a/packages/geom-point/src/geomPoint.tsx
+++ b/packages/geom-point/src/geomPoint.tsx
@@ -30,7 +30,7 @@ import {
   PageVisibility,
 } from '@graphique/graphique'
 import { type GeomAes } from './types'
-import { Tooltip } from './tooltip'
+import { Tooltip } from './Tooltip'
 
 export interface PointProps extends SVGAttributes<SVGCircleElement> {
   data?: unknown[]
@@ -98,7 +98,7 @@ const GeomPoint = ({
   )
 
   const positionKeyAccessor = useCallback(
-    (d: unknown) => 
+    (d: unknown) =>
       `${geomAes?.x && geomAes.x(d)}-${geomAes?.y && geomAes.y(d)}-${
         group && group(d)}` as string
     , [geomAes, group])


### PR DESCRIPTION
was going through the process of running the demo app locally– when building each module with `npm run build -w packages` area, label, line, and point all failed with errors like:

```
(rpt2 plugin) Error: /app/packages/geom-point/src/geomPoint.tsx(33,25): semantic error TS1261: Already included file name '/app/packages/geom-point/src/tooltip/index.ts' differs from file name '/app/packa
ges/geom-point/src/Tooltip/index.ts' only in casing.
  The file is in the program because:
    Imported via './tooltip' from file '/app/packages/geom-point/src/geomPoint.tsx'
    Root file specified for compilation
Error: /app/packages/geom-point/src/geomPoint.tsx(33,25): semantic error TS1261: Already included file name '/app/packages/geom-point/src/tooltip/index.ts' differs from file name '/app/packages/geom-point
/src/Tooltip/index.ts' only in casing.
  The file is in the program because:
    Imported via './tooltip' from file '/app/packages/geom-point/src/geomPoint.tsx'
    Root file specified for compilation
    at error (/app/node_modules/rollup/dist/shared/rollup.js:198:30)
    at throwPluginError (/app/node_modules/rollup/dist/shared/rollup.js:21718:12)
    at Object.error (/app/node_modules/rollup/dist/shared/rollup.js:22672:20)
    at Object.error (/app/node_modules/rollup/dist/shared/rollup.js:21895:42)
    at RollupContext.error (/app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:17237:30)
    at /app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25033:23
    at arrayEach (/app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:545:11)
    at Function.forEach (/app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:9397:14)
    at printDiagnostics (/app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25006:12)
    at Object.transform (/app/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29275:17)
    at /app/node_modules/rollup/dist/shared/rollup.js:22879:40
```

this fixes those errors