### PR TITLE
Revert "fixes TS1261 errors on build"

### DIFF
--- a/packages/geom-area/src/geomArea.tsx
+++ b/packages/geom-area/src/geomArea.tsx
@@ -36,7 +36,7 @@ import {
 import { min, max, sum, extent } from 'd3-array'
 import { useAtom } from 'jotai'
 import type { GeomAes, StackedArea } from './types'
-import { LineMarker, Tooltip } from './Tooltip'
+import { LineMarker, Tooltip } from './tooltip'
 
 export interface GeomAreaProps extends SVGAttributes<SVGPathElement> {
   data?: unknown[]

--- a/packages/geom-label/src/geomLabel.tsx
+++ b/packages/geom-label/src/geomLabel.tsx
@@ -27,7 +27,7 @@ import {
   PageVisibility,
 } from '@graphique/graphique'
 import { type GeomAes } from './types'
-import { Tooltip } from './Tooltip'
+import { Tooltip } from './tooltip'
 
 export interface LabelProps extends SVGAttributes<SVGTextElement> {
   data?: unknown[]
@@ -106,7 +106,7 @@ const GeomLabel = ({
   const getLabel = useMemo(() => {
     if (!geomAes?.label && !label)
       throw new Error('You need to provide a `label` or map a `label` in `aes` in order to use GeomLabel')
-
+      
     return geomAes?.label
   }, [geomAes, label])
 
@@ -360,9 +360,9 @@ const GeomLabel = ({
                         styles = focusedStyles
                       if (focusedKeys?.length > 0 && !focusedKeys.includes(key))
                         styles = unfocusedStyles
-
+                      
                       const nodeX = x(nodeData) ?? 0
-
+                      
                       return (
                         <text
                           key={key}

--- a/packages/geom-line/src/geomLine.tsx
+++ b/packages/geom-line/src/geomLine.tsx
@@ -27,7 +27,7 @@ import { interpolatePath } from 'd3-interpolate-path'
 import { line, CurveFactory, curveLinear } from 'd3-shape'
 import { scaleOrdinal } from 'd3-scale'
 import { useAtom } from 'jotai'
-import { LineMarker, Tooltip } from './Tooltip'
+import { LineMarker, Tooltip } from './tooltip'
 import { type GeomAes } from './types'
 
 export interface LineProps extends SVGAttributes<SVGPathElement> {

--- a/packages/geom-point/src/geomPoint.tsx
+++ b/packages/geom-point/src/geomPoint.tsx
@@ -30,7 +30,7 @@ import {
   PageVisibility,
 } from '@graphique/graphique'
 import { type GeomAes } from './types'
-import { Tooltip } from './Tooltip'
+import { Tooltip } from './tooltip'
 
 export interface PointProps extends SVGAttributes<SVGCircleElement> {
   data?: unknown[]
@@ -98,7 +98,7 @@ const GeomPoint = ({
   )
 
   const positionKeyAccessor = useCallback(
-    (d: unknown) =>
+    (d: unknown) => 
       `${geomAes?.x && geomAes.x(d)}-${geomAes?.y && geomAes.y(d)}-${
         group && group(d)}` as string
     , [geomAes, group])


### PR DESCRIPTION
Reverts graphiquejs/graphique#37. 

The (newer) names for these directories are lower-cased, so turns out they should have lower-cased imports.