### PR TITLE
Updates for event area events + geom-line group accessor + geom-hist tooltip

### DIFF
--- a/packages/geom-histogram/src/geomHistogram.tsx
+++ b/packages/geom-histogram/src/geomHistogram.tsx
@@ -31,6 +31,7 @@ const GeomHistogram = ({
   bins = 30,
   isRelative = false,
   rangeFormat,
+  showTooltip,
   ...props
 }: HistogramProps) => {
   const { ggState } = useGG() || {}
@@ -47,7 +48,7 @@ const GeomHistogram = ({
 
   const rangeFormatter = useCallback(
     (x0: number, x1: number) => {
-      const [x0String, x1String] = [x0.toLocaleString(), x1.toLocaleString()]
+      const [x0String, x1String] = [x0?.toLocaleString(), x1?.toLocaleString()]
 
       if (rangeFormat)
         return rangeFormat(x0, x1)
@@ -172,11 +173,13 @@ const GeomHistogram = ({
   }, [data, setXScale, setYScale, bins, isRelative])
 
   useEffect(() => {
-    setTooltip(prev => ({
-      ...prev,
-      xFormat: formatRange,
-    }))
-  }, [formatRange])
+    if (showTooltip) {
+      setTooltip(prev => ({
+        ...prev,
+        xFormat: formatRange,
+      }))
+    }
+  }, [formatRange, showTooltip])
 
   return !firstRender ? (
     <>
@@ -196,6 +199,7 @@ const GeomHistogram = ({
               xPadding={xPadding}
               align={reversedX ? 'right' : align}
               position="identity"
+              showTooltip={showTooltip}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...props}
             />

--- a/packages/geom-line/src/geomLine.tsx
+++ b/packages/geom-line/src/geomLine.tsx
@@ -174,7 +174,7 @@ const GeomLine = ({
           strokeDasharray,
           stroke: strokeColor,
           strokeScale: geomStrokeScale,
-          groupAccessor: geomAes.stroke ?? geomAes.strokeDasharray,
+          groupAccessor: geomAes.stroke ?? geomAes.strokeDasharray ?? geomAes.group,
           usableGroups: strokeGroups ?? strokeDasharrayGroups,
         },
       },

--- a/packages/graphique/src/util/EventArea.tsx
+++ b/packages/graphique/src/util/EventArea.tsx
@@ -141,10 +141,12 @@ export const EventArea = ({
     const timeout = setTimeout(() => {
       readyToFocusRef.current = true
     }, duration + 50)
+
     return () => clearTimeout(timeout)
   }, [
-    ggData,
-    data,
+    // disable focusing in event area when data is changing
+    JSON.stringify(ggData),
+    JSON.stringify(data),
     width,
     animationDuration,
     xZoomDomain,


### PR DESCRIPTION
- small tooltip adjustment for histogram tooltipping
- adds `aes.group` as a fallback accessor for creating grouped lines with `GeomLine`
- optimizes `EventArea` dependency array for disabling events only when data is _really_ changing