### PR TITLE
use resize observer when isContainerWidth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "react": "^17.0.2",
         "react-docgen-typescript": "^2.0.0",
         "react-dom": "^17.0.2",
+        "resize-observer-polyfill": "^1.5.1",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.1.3"
@@ -26034,6 +26035,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -49762,6 +49769,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^17.0.2",
     "react-docgen-typescript": "^2.0.0",
     "react-dom": "^17.0.2",
+    "resize-observer-polyfill": "^1.5.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.1.3"

--- a/packages/graphique/src/gg/GG.tsx
+++ b/packages/graphique/src/gg/GG.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react'
 import { Provider } from 'jotai'
-import { generateID, debounce } from '../util'
+import { generateID } from '../util'
 import { GGBase } from './GGBase'
 import type { RootGGProps } from './types/GG'
 
@@ -23,12 +23,19 @@ export const GG = ({ children, ...props }: RootGGProps) => {
   }, [isContainerWidth])
 
   useEffect(() => {
-    const resize = debounce(0, () => setGGWidth(ggRef.current?.clientWidth))
-    if (isContainerWidth) {
-      window.addEventListener('resize', resize)
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect;
+      if (isContainerWidth)
+        setGGWidth(rect.width)
+    });
+    if (ggRef.current && isContainerWidth)
+      observer.observe(ggRef.current)
+
+    return () => {
+      if (ggRef.current && isContainerWidth)
+        observer.unobserve(ggRef.current)
     }
-    return () => window.removeEventListener('resize', resize)
-  }, [isContainerWidth])
+  }, [isContainerWidth]);
 
   const id = useMemo(() => generateID(), [])
 

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,7 +1,9 @@
 window.requestAnimationFrame = (callback: any): number => window.setTimeout(() => callback(), 0)
 window.cancelAnimationFrame = (id: any): void => {
-  clearTimeout(id);
+  clearTimeout(id)
 }
+
+global.ResizeObserver = require('resize-observer-polyfill')
 
 Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
 Object.defineProperty(document, 'hidden', { value: false, writable: true })


### PR DESCRIPTION
this removes the resize event listener on `window`, and instead places a `ResizeObserver` on the containing Graphique element