### PR TITLE
Include generic Datum type for aes + data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30418,7 +30418,7 @@
     },
     "packages/geom-line": {
       "name": "@graphique/geom-line",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30552,7 +30552,7 @@
     },
     "packages/graphique": {
       "name": "@graphique/graphique",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30227,7 +30227,7 @@
     },
     "packages/geom-area": {
       "name": "@graphique/geom-area",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30259,7 +30259,7 @@
     },
     "packages/geom-bar": {
       "name": "@graphique/geom-bar",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30293,7 +30293,7 @@
     },
     "packages/geom-col": {
       "name": "@graphique/geom-col",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30329,10 +30329,10 @@
     },
     "packages/geom-histogram": {
       "name": "@graphique/geom-histogram",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@graphique/geom-col": "^1.0.0",
+        "@graphique/geom-col": "^1.0.1",
         "d3-array": "^3.0.1",
         "d3-scale": "^4.0.0",
         "jotai": "^1.1.2"
@@ -30350,7 +30350,7 @@
     },
     "packages/geom-hline": {
       "name": "@graphique/geom-hline",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30386,7 +30386,7 @@
     },
     "packages/geom-label": {
       "name": "@graphique/geom-label",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30452,7 +30452,7 @@
     },
     "packages/geom-point": {
       "name": "@graphique/geom-point",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30484,7 +30484,7 @@
     },
     "packages/geom-tile": {
       "name": "@graphique/geom-tile",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30516,7 +30516,7 @@
     },
     "packages/geom-vline": {
       "name": "@graphique/geom-vline",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30552,7 +30552,7 @@
     },
     "packages/graphique": {
       "name": "@graphique/graphique",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -32241,7 +32241,7 @@
     "@graphique/geom-histogram": {
       "version": "file:packages/geom-histogram",
       "requires": {
-        "@graphique/geom-col": "^1.0.0",
+        "@graphique/geom-col": "^1.0.1",
         "@types/d3-array": "^3.0.1",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30227,7 +30227,7 @@
     },
     "packages/geom-area": {
       "name": "@graphique/geom-area",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30252,14 +30252,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-bar": {
       "name": "@graphique/geom-bar",
-      "version": "0.7.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30286,14 +30286,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-col": {
       "name": "@graphique/geom-col",
-      "version": "0.6.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30322,17 +30322,17 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-histogram": {
       "name": "@graphique/geom-histogram",
-      "version": "0.6.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@graphique/geom-col": "^0.6.2",
+        "@graphique/geom-col": "^1.0.0",
         "d3-array": "^3.0.1",
         "d3-scale": "^4.0.0",
         "jotai": "^1.1.2"
@@ -30343,14 +30343,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-hline": {
       "name": "@graphique/geom-hline",
-      "version": "0.4.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30379,14 +30379,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-label": {
       "name": "@graphique/geom-label",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30411,14 +30411,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-line": {
       "name": "@graphique/geom-line",
-      "version": "1.6.8",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30445,14 +30445,14 @@
         "d3-scale-chromatic": "^3.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-point": {
       "name": "@graphique/geom-point",
-      "version": "1.4.7",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30477,14 +30477,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-tile": {
       "name": "@graphique/geom-tile",
-      "version": "0.5.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30509,14 +30509,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/geom-vline": {
       "name": "@graphique/geom-vline",
-      "version": "0.4.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -30545,14 +30545,14 @@
         "@types/react-dom": "^17.0.0"
       },
       "peerDependencies": {
-        "@graphique/graphique": ">=1",
+        "@graphique/graphique": ">=2",
         "react": ">=16",
         "react-dom": ">=16"
       }
     },
     "packages/graphique": {
       "name": "@graphique/graphique",
-      "version": "1.6.9",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",
@@ -32241,7 +32241,7 @@
     "@graphique/geom-histogram": {
       "version": "file:packages/geom-histogram",
       "requires": {
-        "@graphique/geom-col": "^0.6.2",
+        "@graphique/geom-col": "^1.0.0",
         "@types/d3-array": "^3.0.1",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/packages/geom-area/package.json
+++ b/packages/geom-area/package.json
@@ -45,7 +45,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-area/package.json
+++ b/packages/geom-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-area",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "For area charts, stacked area charts, or streamgraphs",
   "keywords": [
     "react",

--- a/packages/geom-area/package.json
+++ b/packages/geom-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-area",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For area charts, stacked area charts, or streamgraphs",
   "keywords": [
     "react",

--- a/packages/geom-area/src/__tests__/GeomAreaBasics.test.tsx
+++ b/packages/geom-area/src/__tests__/GeomAreaBasics.test.tsx
@@ -10,7 +10,7 @@ import {
   NUM_GROUPS,
   DEFAULT_AES,
   undefinedYValData,
-} from "./shared"
+} from './shared'
 import { GeomArea } from '../geomArea'
 
 jest.useFakeTimers()
@@ -75,10 +75,10 @@ describe('area chart basics with GeomArea', () => {
           y: undefined,
         }}
       >
-        <GeomArea
+        <GeomArea<Stock>
           aes={{
-            y0: (d: Stock) => d.marketCap - (d.marketCap * 0.1),
-            y1: (d: Stock) => d.marketCap + (d.marketCap * 0.1) 
+            y0: d => d.marketCap - (d.marketCap * 0.1),
+            y1: d => d.marketCap + (d.marketCap * 0.1) 
           }}
         />
       </GGArea>
@@ -127,9 +127,9 @@ describe('area chart basics with GeomArea', () => {
     expect(() => {
       render(
         <GGArea {...DEFAULT_AREA_PROPS}>
-          <GeomArea
+          <GeomArea<Stock>
             aes={{
-              y1: (d: Stock) => d.marketCap + (d.marketCap * 0.1)
+              y1: d => d.marketCap + (d.marketCap * 0.1)
             }}
           />
         </GGArea>
@@ -148,10 +148,10 @@ describe('area chart basics with GeomArea', () => {
             y: undefined
           }}
         >
-          <GeomArea
+          <GeomArea<Stock>
             aes={{
-              y0: (d: Stock) => d.marketCap - (d.marketCap * 0.1),
-              y1: (d: Stock) => d.marketCap + (d.marketCap * 0.1)
+              y0: d => d.marketCap - (d.marketCap * 0.1),
+              y1: d => d.marketCap + (d.marketCap * 0.1)
             }}
             position='stack'
           />

--- a/packages/geom-area/src/__tests__/GeomAreaSnapshot.test.tsx
+++ b/packages/geom-area/src/__tests__/GeomAreaSnapshot.test.tsx
@@ -21,11 +21,11 @@ jest.mock('nanoid', () => ({
 jest.useFakeTimers()
 
 interface TestComponentProps {
-  aes?: Aes
+  aes?: Aes<Stock>
   data?: Stock[]
   position?: AreaPositions
-  y0?: DataValue
-  y1?: DataValue
+  y0?: DataValue<Stock>
+  y1?: DataValue<Stock>
 }
 
 const TestComponent = ({
@@ -110,8 +110,8 @@ describe('area charts match snapshots', () => {
           ...DEFAULT_AES,
           y: undefined,
         }}
-        y0={(d: Stock) => d.marketCap - (d.marketCap * 0.1)}
-        y1={(d: Stock) => d.marketCap + (d.marketCap * 0.1)}
+        y0={d => d.marketCap - (d.marketCap * 0.1)}
+        y1={d => d.marketCap + (d.marketCap * 0.1)}
       />
     )
     await prepareTesting(user)

--- a/packages/geom-area/src/__tests__/shared.tsx
+++ b/packages/geom-area/src/__tests__/shared.tsx
@@ -6,17 +6,17 @@ import { GeomArea } from '..'
 
 const GROUPS = Array.from(new Set(stocks.map(c => c.symbol)))
 const NUM_GROUPS = GROUPS.length
-const DEFAULT_AES: Aes = {
-  x: (d: Stock) => new Date(d.date),
-  y: (d: Stock) => d.marketCap,
-  fill: (d: Stock) => d.symbol
+const DEFAULT_AES: Aes<Stock> = {
+  x: d => new Date(d.date),
+  y: d => d.marketCap,
+  fill: d => d.symbol
 }
 const DEFAULT_GROUP_FILLS = defaultScheme.slice(0, NUM_GROUPS)
 const DEFAULT_FILL = '#777777ee'
 
-interface AreaProps<T> {
-  data: T[]
-  aes: Aes
+interface AreaProps<Stock> {
+  data: Stock[]
+  aes: Aes<Stock>
   children?: React.ReactNode
 }
 
@@ -30,7 +30,7 @@ const DEFAULT_AREA_PROPS: AreaProps<Stock> = {
   children: <GeomArea />
 }
 
-const GGArea: React.FC<AreaProps<unknown>> = (props = DEFAULT_AREA_PROPS) => (
+const GGArea: React.FC<AreaProps<Stock>> = (props = DEFAULT_AREA_PROPS) => (
   <GG
     data={props.data}
     aes={props.aes}

--- a/packages/geom-area/src/hooks/useHandleSpecificationErrors.ts
+++ b/packages/geom-area/src/hooks/useHandleSpecificationErrors.ts
@@ -1,17 +1,17 @@
 import { AreaPositions } from "@graphique/graphique"
 import { GeomAes } from "../types"
 
-interface SpecificationErrorProps {
-  geomAes?: GeomAes
+interface SpecificationErrorProps<Datum> {
+  geomAes?: GeomAes<Datum>
   shouldStack?: boolean
   position?: AreaPositions
 }
 
 const GEOM = 'GeomArea'
 
-const useHandleSpecificationErrors = ({ 
+const useHandleSpecificationErrors = <Datum>({ 
   geomAes, shouldStack, position,
- }: SpecificationErrorProps) => {
+ }: SpecificationErrorProps<Datum>) => {
   if (shouldStack && !geomAes?.y) {
     throw new Error(`${GEOM}: aes.y is required when using position="${position}"`)
   }

--- a/packages/geom-area/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-area/src/legend/AppearanceLegend.tsx
@@ -15,7 +15,7 @@ export interface AppearanceLegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -24,7 +24,7 @@ export const Legend = ({
   // width,
   onSelection,
 }: AppearanceLegendProps) => {
-  const { ggState } = useGG() || {}
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font, geoms }] = useAtom(themeState)
 
@@ -60,7 +60,7 @@ export const Legend = ({
                   ? area.strokeScale
                   : copiedScales?.strokeScale,
                 fillScale: area ? area.fillScale : copiedScales?.fillScale,
-              } as IScale
+              } as IScale<Datum>
             }
             labelFormat={format}
             fontSize={fontSize}

--- a/packages/geom-area/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-area/src/legend/CategoricalLegend.tsx
@@ -8,23 +8,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface CategoricalLegendProps {
-  legendData: unknown[]
-  legendScales: IScale
+export interface CategoricalLegendProps<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: CategoricalLegendProps) => {
+}: CategoricalLegendProps<Datum>) => {
   const [focused, setFocused] = useState<string[]>(
     legendScales.groups || legendScales.fillScale?.domain() || []
   )
@@ -40,7 +40,7 @@ export const CategoricalLegend = ({
     [domain, legendScales]
   )
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
@@ -80,7 +80,7 @@ export const CategoricalLegend = ({
         let updatedData
         if (includedGroups.includes(g)) {
           if (includedGroups.length === 1) {
-            updatedData = legendData as unknown[]
+            updatedData = legendData
           } else {
             updatedData = data.filter((d) => getGroup(d) !== g)
           }

--- a/packages/geom-area/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-area/src/tooltip/DefaultTooltip.tsx
@@ -7,17 +7,17 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface DefaultTooltipProps {
-  data: TooltipContent[]
+export interface DefaultTooltipProps<Datum> {
+  data: TooltipContent<Datum>[]
   hasXAxisTooltip?: boolean
   geomID: string
 }
 
-export const DefaultTooltip = ({
+export const DefaultTooltip = <Datum,>({
   data,
   hasXAxisTooltip,
   geomID,
-}: DefaultTooltipProps) => {
+}: DefaultTooltipProps<Datum>) => {
   const xVal = data && data[0] ? data[0]?.formattedX : undefined
 
   const [{ tooltip }] = useAtom(themeState)
@@ -36,7 +36,7 @@ export const DefaultTooltip = ({
           {xVal}
         </div>
       )}
-      {data.map((d: TooltipContent, i: number) => {
+      {data.map((d, i: number) => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div

--- a/packages/geom-area/src/tooltip/LineMarker.tsx
+++ b/packages/geom-area/src/tooltip/LineMarker.tsx
@@ -3,24 +3,23 @@ import {
   useGG,
   tooltipState,
   themeState,
-  DataValue,
   formatMissing,
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { sum, min } from 'd3-array'
 import type { GeomAes } from '../types'
 
-export interface LineMarkerProps {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
-  y0: DataValue
-  y1: DataValue
-  aes: GeomAes
+export interface LineMarkerProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
+  y0: (d: Datum) => number | undefined
+  y1: (d: Datum) => number | undefined
+  aes: GeomAes<Datum>
   markerRadius: number
   markerStroke: string
 }
 
-export const LineMarker = ({
+export const LineMarker = <Datum,>({
   x,
   y,
   y0,
@@ -28,8 +27,8 @@ export const LineMarker = ({
   aes,
   markerRadius,
   markerStroke,
-}: LineMarkerProps) => {
-  const { ggState } = useGG() || {}
+}: LineMarkerProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { scales, copiedScales, width, height, margin, id } = ggState || {}
 
   const [{ datum }] = useAtom(tooltipState)

--- a/packages/geom-area/src/tooltip/Tooltip.tsx
+++ b/packages/geom-area/src/tooltip/Tooltip.tsx
@@ -7,7 +7,6 @@ import {
   XTooltip,
   YTooltip,
   TooltipContainer,
-  DataValue,
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { mean, sum, min, max } from 'd3-array'
@@ -16,17 +15,17 @@ import type { GeomAes } from '../types'
 
 export { LineMarker } from './LineMarker'
 
-interface Props {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
-  y0: DataValue
-  y1: DataValue
-  aes: GeomAes
+interface Props<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
+  y0: (d: Datum) => number | undefined
+  y1: (d: Datum) => number | undefined
+  aes: GeomAes<Datum>
   geomID: string
 }
 
-export const Tooltip = ({ x, y, y0, y1, aes, geomID }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ x, y, y0, y1, aes, geomID }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, copiedScales, width, height, margin } = ggState || {
     height: 0,
   }
@@ -172,7 +171,7 @@ export const Tooltip = ({ x, y, y0, y1, aes, geomID }: Props) => {
         formattedX: xFormat ? xFormat(xVal) : xVal.toString(),
       }
     })
-    return vals as TooltipContent[]
+    return vals as TooltipContent<Datum>[]
   }, [
     datumInGroups,
     xVal,

--- a/packages/geom-area/src/tooltip/Tooltip.tsx
+++ b/packages/geom-area/src/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
   XTooltip,
   YTooltip,
   TooltipContainer,
+  TooltipProps,
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { mean, sum, min, max } from 'd3-array'
@@ -31,7 +32,7 @@ export const Tooltip = <Datum,>({ x, y, y0, y1, aes, geomID }: Props<Datum>) => 
   }
 
   const [{ datum, position, xAxis, xFormat, yFormat, content }] =
-    useAtom(tooltipState)
+    useAtom<TooltipProps<Datum>>(tooltipState)
 
   const [{ geoms, defaultStroke, defaultFill }] = useAtom(themeState)
   const { area } = geoms || {}
@@ -165,10 +166,11 @@ export const Tooltip = <Datum,>({ x, y, y0, y1, aes, geomID }: Props<Datum>) => 
       return {
         group: autoGrouped ? undefined : thisGroup,
         mark: thisGroup && !autoGrouped ? mark : undefined,
+        datum,
         x: xVal,
         y: (aes?.y1 && aes?.y1(md)) ?? (aes?.y && aes.y(md)),
         formattedY,
-        formattedX: xFormat ? xFormat(xVal) : xVal.toString(),
+        formattedX: xFormat ? xFormat(xVal) : String(xVal),
       }
     })
     return vals as TooltipContent<Datum>[]

--- a/packages/geom-area/src/types/index.ts
+++ b/packages/geom-area/src/types/index.ts
@@ -1,17 +1,17 @@
 import { DataValue, Aes } from "@graphique/graphique"
 
-export type GeomAes = Omit<Aes, 'x' | 'size'> &
+export type GeomAes<Datum> = Omit<Aes<Datum>, 'x' | 'size'> &
 {
-  x?: DataValue
+  x?: DataValue<Datum>
   /** a functional mapping to `data` representing an initial **y** value */
-  y0?: DataValue
+  y0?: DataValue<Datum>
   /** a functional mapping to `data` representing a secondary **y** value */
-  y1?: DataValue
+  y1?: DataValue<Datum>
 }
 
 export type StackedArea = {
   x: number
-  i: number
+  group: string
   y0: number
   y1: number
 }

--- a/packages/geom-bar/package.json
+++ b/packages/geom-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-bar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For visualizing data as horizontal bars",
   "keywords": [
     "react",

--- a/packages/geom-bar/package.json
+++ b/packages/geom-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-bar",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "For visualizing data as horizontal bars",
   "keywords": [
     "react",

--- a/packages/geom-bar/package.json
+++ b/packages/geom-bar/package.json
@@ -47,7 +47,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-bar/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-bar/src/legend/AppearanceLegend.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, CSSProperties } from 'react'
-import { useGG, themeState, IScale } from '@graphique/graphique'
+import { useGG, themeState } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 import { ColorBandLegend } from './ColorBandLegend'
@@ -14,7 +14,7 @@ export interface AppearanceLegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -23,7 +23,7 @@ export const Legend = ({
   width,
   onSelection,
 }: AppearanceLegendProps) => {
-  const { ggState } = useGG() || {}
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font }] = useAtom(themeState)
 
@@ -60,7 +60,7 @@ export const Legend = ({
         />
       ) : (
         <ColorBandLegend
-          scales={copiedScales as IScale}
+          scales={copiedScales}
           tickFormat={format}
           numTicks={numTicks}
           fontSize={fontSize}

--- a/packages/geom-bar/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-bar/src/legend/CategoricalLegend.tsx
@@ -9,23 +9,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface Props {
-  legendData: unknown[]
-  legendScales: IScale
+export interface Props<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: Props) => {
+}: Props<Datum>) => {
   const [isFocused, setIsFocused] = useState<string[]>(
     legendScales.groups || []
   )
@@ -37,14 +37,14 @@ export const CategoricalLegend = ({
   const legendGroups =
     ((fillDomain || strokeDomain) as string[]) || legendScales.groups
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
     setIsFocused(scales?.groups || [])
   }, [scales, data])
 
-  const getGroup: any = legendScales.groupAccessor
+  const getGroup = legendScales.groupAccessor
     ? legendScales.groupAccessor
     : () => legendScales.groups && legendScales.groups[0]
 
@@ -73,7 +73,7 @@ export const CategoricalLegend = ({
       let updatedData
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-bar/src/legend/ColorBandLegend.tsx
+++ b/packages/geom-bar/src/legend/ColorBandLegend.tsx
@@ -11,8 +11,8 @@ import { select } from 'd3-selection'
 import { axisBottom } from 'd3-axis'
 import { range, quantile } from 'd3-array'
 
-export interface ColorBandLegendProps {
-  scales: IScale
+export interface ColorBandLegendProps<Datum> {
+  scales: IScale<Datum>
   tickFormat?: (v: unknown, i: number) => string
   width?: number
   tickSize?: number
@@ -27,7 +27,7 @@ export interface ColorBandLegendProps {
   fontSize?: number | string
 }
 
-export const ColorBandLegend = ({
+export const ColorBandLegend = <Datum,>({
   scales,
   tickFormat,
   width = 320,
@@ -36,7 +36,7 @@ export const ColorBandLegend = ({
   margin,
   numTicks = width / 64,
   fontSize = 10,
-}: ColorBandLegendProps) => {
+}: ColorBandLegendProps<Datum>) => {
   const legendRef = useRef<SVGSVGElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const axisRef = useRef<SVGGElement | null>(null)
@@ -66,7 +66,7 @@ export const ColorBandLegend = ({
     ...margin,
   }
   const drawLegend = useCallback(
-    (scale: any, font?: string) => {
+    (scale, font?: string) => {
       if (
         legendRef.current &&
         canvasRef.current &&

--- a/packages/geom-bar/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-bar/src/tooltip/DefaultTooltip.tsx
@@ -7,11 +7,11 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
   const yVal = data && data[0].formattedY
 
   const [{ tooltip }] = useAtom(themeState)
@@ -28,7 +28,7 @@ export const DefaultTooltip = ({ data }: Props) => {
       >
         {yVal}
       </div>
-      {data.map((d: TooltipContent, i: number) => {
+      {data.map((d, i) => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div

--- a/packages/geom-bar/src/tooltip/Tooltip.tsx
+++ b/packages/geom-bar/src/tooltip/Tooltip.tsx
@@ -9,6 +9,7 @@ import {
   YTooltip,
   Aes,
   themeState,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
@@ -18,7 +19,7 @@ interface StackMidpoint {
   xVal: number
 }
 
-export interface TooltipProps<Datum> {
+interface Props<Datum> {
   x: (d: Datum) => number | undefined
   y: (d: Datum) => number | undefined
   yAdj?: number
@@ -36,13 +37,13 @@ export const Tooltip = <Datum,>({
   focusType,
   align,
   stackMidpoints,
-}: TooltipProps<Datum>) => {
+}: Props<Datum>) => {
   const { ggState } = useGG<Datum>() || {}
   const { id, scales, copiedScales, height } = ggState || {
     height: 0,
   }
 
-  const [{ datum, xFormat, yFormat, content }] = useAtom(tooltipState)
+  const [{ datum, xFormat, yFormat, content }] = useAtom<TooltipProps<Datum>>(tooltipState)
 
   const [{ geoms }] = useAtom(themeState)
 
@@ -52,7 +53,7 @@ export const Tooltip = <Datum,>({
   )
 
   const yCoord = useMemo(
-    () => datum?.[0] && (y(datum[0]) ?? 0) + (focusType === 'group' ? yAdj : 0),
+    () => (datum?.[0] && (y(datum?.[0]) ?? 0) + (focusType === 'group' ? yAdj : 0)) || 0,
     [yAdj, datum, y, focusType]
   )
 
@@ -138,7 +139,7 @@ export const Tooltip = <Datum,>({
             x: xVal,
             y: yVal,
             formattedX: xFormat ? xFormat(aes?.x(md)) : aes?.x(md),
-            formattedY: yFormat ? yFormat(yVal) : yVal.toString(),
+            formattedY: yFormat ? yFormat(yVal) : String(yVal),
           }
         })
     return vals as TooltipContent<Datum>[]

--- a/packages/geom-bar/src/tooltip/Tooltip.tsx
+++ b/packages/geom-bar/src/tooltip/Tooltip.tsx
@@ -18,17 +18,17 @@ interface StackMidpoint {
   xVal: number
 }
 
-export interface TooltipProps {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
+export interface TooltipProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
   yAdj?: number
-  aes?: Aes
+  aes?: Aes<Datum>
   focusType: 'group' | 'individual'
   align: 'left' | 'center' | 'right'
   stackMidpoints?: StackMidpoint[]
 }
 
-export const Tooltip = ({
+export const Tooltip = <Datum,>({
   x,
   y,
   yAdj = 0,
@@ -36,8 +36,8 @@ export const Tooltip = ({
   focusType,
   align,
   stackMidpoints,
-}: TooltipProps) => {
-  const { ggState } = useGG() || {}
+}: TooltipProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, copiedScales, height } = ggState || {
     height: 0,
   }
@@ -141,7 +141,7 @@ export const Tooltip = ({
             formattedY: yFormat ? yFormat(yVal) : yVal.toString(),
           }
         })
-    return vals as TooltipContent[]
+    return vals as TooltipContent<Datum>[]
   }, [
     datum,
     yVal,

--- a/packages/geom-col/package.json
+++ b/packages/geom-col/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-col",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For visualizing data as vertical bars (columns)",
   "keywords": [
     "react",

--- a/packages/geom-col/package.json
+++ b/packages/geom-col/package.json
@@ -48,7 +48,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-col/package.json
+++ b/packages/geom-col/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-col",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "description": "For visualizing data as vertical bars (columns)",
   "keywords": [
     "react",

--- a/packages/geom-col/src/__tests__/GeomColSnapshot.test.tsx
+++ b/packages/geom-col/src/__tests__/GeomColSnapshot.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { GG, type Aes, type BarColPositions, Theme, Tooltip } from '@graphique/graphique'
 import { screen, act } from '@testing-library/react'
-import { Stock, stocks } from '@graphique/datasets'
+import { stocks } from '@graphique/datasets'
 import { GeomCol, Legend } from '..'
 import { arrestsByDay, arrestsByDayAndCrime } from './__data__/crimeTotals'
-import { CrimeTotal, DEFAULT_AES, GGCol, setup } from './shared'
+import { type CrimeCount, DEFAULT_AES, GGCol, setup } from './shared'
 
 // useful for controlling the randomly-generated ID given to graphique objects
 jest.mock('nanoid', () => ({
@@ -13,8 +13,8 @@ jest.mock('nanoid', () => ({
 
 jest.useFakeTimers()
 
-interface TestComponentProps {
-  aes?: Aes
+interface TestComponentProps<CrimeTotal> {
+  aes?: Aes<CrimeTotal>
   data?: CrimeTotal[]
   position?: BarColPositions
   focusType?: 'group' | 'individual'
@@ -25,7 +25,7 @@ const TestComponent = ({
   data = arrestsByDayAndCrime,
   position = 'stack',
   focusType = 'individual',
-}: TestComponentProps) => (
+}: TestComponentProps<CrimeCount>) => (
   <GG
     data={data}
     aes={aes}
@@ -97,7 +97,7 @@ describe('column charts match snapshots', () => {
       <TestComponent
         aes={{
           ...DEFAULT_AES,
-          stroke: (d: CrimeTotal) => d.offenseCategory!,
+          stroke: d => d.offenseCategory!,
         }}
         position='dodge'
       />
@@ -165,8 +165,8 @@ describe('column charts match snapshots', () => {
           new Date(d.date) >= new Date('2019-07-01')
         ))}
         aes={{
-          x: (d: Stock) => new Date(d.date),
-          y: (d: Stock) => d.marketCap,
+          x: d => new Date(d.date),
+          y: d => d.marketCap,
         }}
       >
         <GeomCol

--- a/packages/geom-col/src/__tests__/__data__/crimeTotals.ts
+++ b/packages/geom-col/src/__tests__/__data__/crimeTotals.ts
@@ -1,10 +1,15 @@
-import { crimes } from '@graphique/datasets'
+import { crimes, type Crime } from '@graphique/datasets'
 import { bivariateSummary } from '../../../../../test/utils'
 
-const arrestsByDayAndCrime = bivariateSummary(crimes, 'dow', 'offenseCategory', d => d?.count)
-const arrestsByDay = bivariateSummary(crimes, 'dow', undefined, d => d?.count)
+type CrimeCount = (Crime & {
+  count: number;
+})
+
+const arrestsByDayAndCrime: CrimeCount[] = bivariateSummary(crimes, 'dow', 'offenseCategory', d => d?.count)
+const arrestsByDay: CrimeCount[] = bivariateSummary(crimes, 'dow', undefined, d => d?.count)
 
 export {
   arrestsByDayAndCrime,
   arrestsByDay,
+  type CrimeCount,
 }

--- a/packages/geom-col/src/__tests__/shared.tsx
+++ b/packages/geom-col/src/__tests__/shared.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { crimes } from '@graphique/datasets'
 import { GG, Aes, defaultScheme } from '@graphique/graphique'
-import { arrestsByDayAndCrime } from './__data__/crimeTotals'
+import { type CrimeCount, arrestsByDayAndCrime } from './__data__/crimeTotals'
 import { setup } from '../../../../test/utils'
 import { GeomCol } from '..'
 
@@ -9,7 +9,7 @@ const COLS = Array.from(new Set(crimes.map(c => c.dow)))
 const GROUPS = Array.from(new Set(crimes.map(c => c.offenseCategory)))
 const NUM_COLS = COLS.length
 const NUM_GROUPS = GROUPS.length
-const DEFAULT_AES: Aes = {
+const DEFAULT_AES: Aes<CrimeCount> = {
   x: d => d.dow,
   y: d => d.count,
   fill: d => d.offenseCategory
@@ -17,23 +17,18 @@ const DEFAULT_AES: Aes = {
 const DEFAULT_GROUP_FILLS = defaultScheme.slice(0, NUM_GROUPS)
 const DEFAULT_FILL = '#777777ee'
 
-interface ColProps {
-  data?: unknown[]
-  aes?: Aes
+interface ColProps<Datum> {
+  data?: Datum[]
+  aes?: Aes<Datum>
+  children?: React.ReactNode
 }
 
-type CrimeTotal = {
-  dow: string
-  offenseCategory?: string
-  count: number
-}
-
-const GGCol: React.FC<ColProps> = (
+const GGCol = (
   {
     data = arrestsByDayAndCrime,
     aes = DEFAULT_AES,
     children = <GeomCol />,
-  }
+  }: ColProps<any>
 ) => (
   <GG
     data={data}
@@ -53,6 +48,6 @@ export {
   DEFAULT_GROUP_FILLS,
   setup,
   GGCol,
-  type CrimeTotal,
   type ColProps,
+  type CrimeCount,
 }

--- a/packages/geom-col/src/index.ts
+++ b/packages/geom-col/src/index.ts
@@ -1,2 +1,3 @@
-export { GeomCol, GeomColProps } from './geomCol'
+export { GeomCol, type GeomColProps } from './geomCol'
 export { Legend } from './legend'
+export type { HistogramBin } from './types'

--- a/packages/geom-col/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-col/src/legend/AppearanceLegend.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useEffect, useState } from 'react'
-import { useGG, themeState, IScale } from '@graphique/graphique'
+import { useGG, themeState } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 import { ColorBandLegend } from './ColorBandLegend'
@@ -14,7 +14,7 @@ export interface LegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -23,7 +23,7 @@ export const Legend = ({
   width,
   onSelection,
 }: LegendProps) => {
-  const { ggState } = useGG() || {}
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font }] = useAtom(themeState)
 
@@ -60,7 +60,7 @@ export const Legend = ({
         />
       ) : (
         <ColorBandLegend
-          scales={copiedScales as IScale}
+          scales={copiedScales}
           tickFormat={format}
           numTicks={numTicks}
           fontSize={fontSize}

--- a/packages/geom-col/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-col/src/legend/CategoricalLegend.tsx
@@ -9,23 +9,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface Props {
-  legendData: unknown[]
-  legendScales: IScale
+export interface Props<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: Props) => {
+}: Props<Datum>) => {
   const [isFocused, setIsFocused] = useState<string[]>(
     legendScales.groups || []
   )
@@ -37,7 +37,7 @@ export const CategoricalLegend = ({
   const legendGroups =
     ((fillDomain || strokeDomain) as string[]) || legendScales.groups
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
@@ -73,7 +73,7 @@ export const CategoricalLegend = ({
       let updatedData
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-col/src/legend/ColorBandLegend.tsx
+++ b/packages/geom-col/src/legend/ColorBandLegend.tsx
@@ -11,8 +11,8 @@ import { select } from 'd3-selection'
 import { axisBottom } from 'd3-axis'
 import { range, quantile } from 'd3-array'
 
-export interface ColorBandLegendProps {
-  scales: IScale
+export interface ColorBandLegendProps<Datum> {
+  scales: IScale<Datum>
   tickFormat?: (v: unknown, i: number) => string
   width?: number
   tickSize?: number
@@ -27,7 +27,7 @@ export interface ColorBandLegendProps {
   fontSize?: number | string
 }
 
-export const ColorBandLegend = ({
+export const ColorBandLegend = <Datum,>({
   scales,
   tickFormat,
   width = 320,
@@ -36,7 +36,7 @@ export const ColorBandLegend = ({
   margin,
   numTicks = width / 64,
   fontSize = 10,
-}: ColorBandLegendProps) => {
+}: ColorBandLegendProps<Datum>) => {
   const legendRef = useRef<SVGSVGElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const axisRef = useRef<SVGGElement | null>(null)

--- a/packages/geom-col/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-col/src/tooltip/DefaultTooltip.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {
-  useGG,
   TooltipContent,
   TooltipContainer,
   formatMissing,
@@ -13,9 +12,6 @@ interface Props<Datum> {
 }
 
 export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
-  const { ggState } = useGG<Datum>() || {}
-  const { aes } = ggState || {}
-
   const xVal = data && data[0].formattedX
 
   const [{ tooltip }] = useAtom(themeState)
@@ -36,13 +32,9 @@ export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div
-            key={
-              aes?.key
-                ? aes.key(d.datum)
-                : `group-tooltip-${
-                    d.label || d.group !== '__group' ? formattedGroup : i
-                  }`
-            }
+            key={`group-tooltip-${
+              d.label || d.group !== '__group' ? formattedGroup : i
+            }`}
           >
             <div
               style={{

--- a/packages/geom-col/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-col/src/tooltip/DefaultTooltip.tsx
@@ -8,12 +8,12 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
-  const { ggState } = useGG() || {}
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { aes } = ggState || {}
 
   const xVal = data && data[0].formattedX
@@ -32,13 +32,13 @@ export const DefaultTooltip = ({ data }: Props) => {
       >
         {xVal}
       </div>
-      {data.map((d: TooltipContent, i: number) => {
+      {data.map((d, i) => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div
             key={
               aes?.key
-                ? aes.key(d)
+                ? aes.key(d.datum)
                 : `group-tooltip-${
                     d.label || d.group !== '__group' ? formattedGroup : i
                   }`

--- a/packages/geom-col/src/tooltip/LineMarker.tsx
+++ b/packages/geom-col/src/tooltip/LineMarker.tsx
@@ -1,25 +1,26 @@
 import React, { useMemo } from 'react'
 import {
+  TooltipProps,
   tooltipState,
   useGG,
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface LineMarkerProps {
-  x: (d: unknown) => number | undefined
+export interface LineMarkerProps<Datum> {
+  x: (d: Datum) => number | undefined
   xAdj?: number
 }
 
-export const LineMarker = ({
+export const LineMarker = <Datum,>({
   x,
   xAdj = 0,
-}: LineMarkerProps) => {
-  const { ggState } = useGG() || {}
+}: LineMarkerProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, height, margin } = ggState || {
     height: 0,
   }
 
-  const [{ datum }] = useAtom(tooltipState)
+  const [{ datum }] = useAtom<TooltipProps<Datum>>(tooltipState)
 
   const xCoord = useMemo(
     () => datum?.[0] && (x(datum[0]) ?? 0) + xAdj,

--- a/packages/geom-col/src/tooltip/Tooltip.tsx
+++ b/packages/geom-col/src/tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import {
   useGG,
   tooltipState,
   TooltipContent,
+  type TooltipProps as TooltipState,
   XTooltip,
   Aes,
   themeState,
@@ -17,30 +18,30 @@ interface StackMidpoint {
   xVal: number
 }
 
-export interface TooltipProps {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
+export interface TooltipProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
   xAdj?: number
-  aes?: Aes
+  aes?: Aes<Datum>
   focusType: 'group' | 'individual'
   stackMidpoints?: StackMidpoint[]
 }
 
-export const Tooltip = ({
+export const Tooltip = <Datum,>({
   x,
   y,
   xAdj = 0,
   aes,
   focusType,
   stackMidpoints,
-}: TooltipProps) => {
-  const { ggState } = useGG() || {}
+}: TooltipProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { data, id, scales, copiedScales, height, margin } = ggState || {
     width: 0,
     height: 0,
   }
 
-  const [{ datum, position, xAxis, xFormat, yFormat, content }] = useAtom(tooltipState)
+  const [{ datum, position, xAxis, xFormat, yFormat, content }] = useAtom<TooltipState<Datum>>(tooltipState)
 
   const [{ geoms }] = useAtom(themeState)
 
@@ -67,7 +68,7 @@ export const Tooltip = ({
       const datumGroup = group(datum[0])
       const focusedStack = stackMidpoints.find(
         ({ xVal: stackX, groupVal }) =>
-          stackX === xVal.valueOf() && groupVal === datumGroup
+          stackX === xVal?.valueOf() && groupVal === datumGroup
       )
 
       const yAesVal = aes?.y?.(datum[0]) as number
@@ -145,10 +146,10 @@ export const Tooltip = ({
             x: xVal,
             y: yVal,
             formattedY: aes?.y && (yFormat ? yFormat(aes.y(md)) : aes.y(md)),
-            formattedX: xFormat ? xFormat(xVal) : xVal.toString(),
+            formattedX: xFormat ? xFormat(xVal) : xVal?.toString(),
           }
         })
-    return vals as TooltipContent[]
+    return vals as TooltipContent<Datum>[]
   }, [
     datum,
     xVal,

--- a/packages/geom-col/src/types/index.ts
+++ b/packages/geom-col/src/types/index.ts
@@ -1,5 +1,12 @@
 import { Aes, DataValue } from '@graphique/graphique'
 
-export type GeomAes = Omit<Aes, 'x' | 'size'> & {
-  x?: DataValue
+export type GeomAes<Datum> = Omit<Aes<Datum>, 'x' | 'size'> & {
+  x?: DataValue<Datum>
+}
+
+export interface HistogramBin {
+  n: number
+  group: string
+  x0?: number
+  x1?: number
 }

--- a/packages/geom-histogram/package.json
+++ b/packages/geom-histogram/package.json
@@ -41,7 +41,7 @@
     "jotai": "^1.1.2"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-histogram/package.json
+++ b/packages/geom-histogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-histogram",
-  "version": "0.6.4",
+  "version": "1.0.0",
   "description": "For visualizing histograms",
   "keywords": [
     "react",
@@ -35,7 +35,7 @@
     "watch": "microbundle watch --jsx React.createElement --jsxFragment React.Fragment -f modern,cjs --compress -o dist/index.js"
   },
   "dependencies": {
-    "@graphique/geom-col": "^0.6.2",
+    "@graphique/geom-col": "^1.0.0",
     "d3-array": "^3.0.1",
     "d3-scale": "^4.0.0",
     "jotai": "^1.1.2"

--- a/packages/geom-histogram/package.json
+++ b/packages/geom-histogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-histogram",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For visualizing histograms",
   "keywords": [
     "react",
@@ -35,7 +35,7 @@
     "watch": "microbundle watch --jsx React.createElement --jsxFragment React.Fragment -f modern,cjs --compress -o dist/index.js"
   },
   "dependencies": {
-    "@graphique/geom-col": "^1.0.0",
+    "@graphique/geom-col": "^1.0.1",
     "d3-array": "^3.0.1",
     "d3-scale": "^4.0.0",
     "jotai": "^1.1.2"

--- a/packages/geom-hline/package.json
+++ b/packages/geom-hline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-hline",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "For drawing horizontal lines (usually used as markers)",
   "keywords": [
     "react",

--- a/packages/geom-hline/package.json
+++ b/packages/geom-hline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-hline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For drawing horizontal lines (usually used as markers)",
   "keywords": [
     "react",

--- a/packages/geom-hline/package.json
+++ b/packages/geom-hline/package.json
@@ -47,7 +47,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-hline/src/__tests__/GeomHLineBasics.test.tsx
+++ b/packages/geom-hline/src/__tests__/GeomHLineBasics.test.tsx
@@ -7,8 +7,8 @@ import {
   DEFAULT_GROUP_STROKES,
   DEFAULT_AES,
   DEFAULT_STROKE_WIDTH,
-} from "./shared"
-import { flipperLengthsBySpecies, type PenguinSummary } from './shared'
+  flipperLengthsBySpecies,
+} from './shared'
 import { GeomHLine } from '../geomHLine'
 
 jest.useFakeTimers()
@@ -19,7 +19,7 @@ describe('horizontal line basics with GeomHLine', () => {
       <GGHLine
         aes={{
           ...DEFAULT_AES,
-          y: (d: PenguinSummary) => d.count!
+          y: d => d.count!
         }}
       />
     )
@@ -50,7 +50,7 @@ describe('horizontal line basics with GeomHLine', () => {
         <GeomHLine
           data={flipperLengthsBySpecies}
           aes={{
-            y: (d: PenguinSummary) => d.count!
+            y: d => d.count!
           }}
         />
       </GGHLine>

--- a/packages/geom-hline/src/__tests__/GeomHLineSnapshot.test.tsx
+++ b/packages/geom-hline/src/__tests__/GeomHLineSnapshot.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { Penguin, penguins } from '@graphique/datasets'
+import { penguins } from '@graphique/datasets'
 import { act, screen } from '@testing-library/react'
 import {
   GGHLine,
   DEFAULT_AES,
   flipperLengthsBySpecies,
-  setup,
-  type PenguinSummary,
+  setup
 } from './shared'
 import { GeomHLine } from '../geomHLine'
 import { GeomPoint } from '../../../geom-point/dist'
@@ -25,7 +24,7 @@ describe('a chart with vertical lines matches a snapshot', () => {
         <GeomHLine
           data={flipperLengthsBySpecies}
           aes={{
-            y: (d: PenguinSummary) => d.count!,
+            y: d => d.count!
           }}
           strokeDasharray='2,1'
         />
@@ -43,13 +42,13 @@ describe('a chart with vertical lines matches a snapshot', () => {
         data={penguins.filter(d => DEFAULT_AES.x(d) && DEFAULT_AES?.y?.(d))}
         aes={{
           ...DEFAULT_AES,
-          fill: (d: Penguin) => d.species
+          fill: d => d.species
         }}
       >
         <GeomHLine
           data={flipperLengthsBySpecies}
           aes={{
-            y: (d: PenguinSummary) => d.count!,
+            y: d => d.count!,
           }}
           strokeDasharray='2,1'
           showTooltip={false}

--- a/packages/geom-hline/src/__tests__/shared.tsx
+++ b/packages/geom-hline/src/__tests__/shared.tsx
@@ -11,15 +11,15 @@ const NUM_GROUPS = GROUPS.length
 const DEFAULT_GROUP_STROKES = defaultScheme.slice(0, NUM_GROUPS)
 const DEFAULT_STROKE_WIDTH = '1.5'
 const DEFAULT_SINGLE_STROKE = '#777777ee'
-const DEFAULT_AES: Aes = {
-  x: (d: PenguinSummary) => d.beakLength,
-  y: (d: PenguinSummary) => d.flipperLength,
-  stroke: (d: PenguinSummary) => d.species,
+const DEFAULT_AES: Aes<PenguinSummary> = {
+  x: d => d.beakLength,
+  y: d => d.flipperLength,
+  stroke: d => d.species,
 }
 
 interface HLineProps {
-  data?: unknown[]
-  aes?: Aes
+  data?: PenguinSummary[]
+  aes?: Aes<PenguinSummary>
 }
 
 const GGHLine: React.FC<HLineProps> = (

--- a/packages/geom-hline/src/geomHLine.tsx
+++ b/packages/geom-hline/src/geomHLine.tsx
@@ -119,12 +119,12 @@ const GeomHLine = <Datum,>({
   )
 
   const keyAccessor = useMemo(
-    () => (d: Datum) =>
+    () => (d: Datum, i: number) =>
       geomAes?.key
         ? geomAes.key(d)
         : (`${geomAes?.y && geomAes.y(d)}-${
             scales?.groupAccessor && scales.groupAccessor(d)
-          }` as string),
+          }-${i}` as string),
     [geomAes, scales]
   )
 

--- a/packages/geom-hline/src/geomHLine.tsx
+++ b/packages/geom-hline/src/geomHLine.tsx
@@ -19,23 +19,23 @@ import { easeCubic } from 'd3-ease'
 import { interpolate } from 'd3-interpolate'
 import { Tooltip } from './tooltip'
 
-type GeomAes = Omit<Aes, 'x' | 'fill' | 'size'>
+type GeomAes<Datum> = Omit<Aes<Datum>, 'x' | 'fill' | 'size'>
 
 const DEFAULT_TICK_SIZE = 6
 
-export interface GeomHLineProps extends SVGAttributes<SVGLineElement> {
-  data?: unknown[]
-  aes?: GeomAes
+export interface GeomHLineProps<Datum> extends SVGAttributes<SVGLineElement> {
+  data?: Datum[]
+  aes?: GeomAes<Datum>
   focusedStyle?: CSSProperties
   unfocusedStyle?: CSSProperties
   showTooltip?: boolean
-  onDatumFocus?: (data: unknown, index: number[]) => void
-  onDatumSelection?: (data: unknown, index: number[]) => void
+  onDatumFocus?: (data: Datum[], index: number[]) => void
+  onDatumSelection?: (data: Datum[], index: number[]) => void
   onExit?: () => void
   strokeOpacity?: number
 }
 
-const GeomHLine = ({
+const GeomHLine = <Datum,>({
   data: localData,
   aes: localAes,
   focusedStyle,
@@ -47,8 +47,8 @@ const GeomHLine = ({
   strokeWidth = 1.5,
   strokeOpacity = 1,
   ...props
-}: GeomHLineProps) => {
-  const { ggState } = useGG() || {}
+}: GeomHLineProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { data, aes, scales, copiedScales, width, margin } = ggState || {}
 
   const geomData = localData || data
@@ -89,7 +89,7 @@ const GeomHLine = ({
   }, [setTheme, strokeColor, strokeOpacity, strokeWidth, props.style])
 
   const stroke = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       strokeColor ||
       (geomAes?.stroke && copiedScales?.strokeScale
         ? (copiedScales.strokeScale(geomAes.stroke(d) as any) as
@@ -100,13 +100,13 @@ const GeomHLine = ({
   )
 
   const y = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       scales?.yScale && geomAes?.y && scales.yScale(geomAes.y(d)),
     [scales, geomAes]
   )
 
   const checkIsOutisdeDomain = useMemo(
-    () => (d: unknown) => {
+    () => (d: Datum) => {
       const domain = scales?.yScale && scales.yScale.domain()
 
       return (
@@ -119,7 +119,7 @@ const GeomHLine = ({
   )
 
   const keyAccessor = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       geomAes?.key
         ? geomAes.key(d)
         : (`${geomAes?.y && geomAes.y(d)}-${
@@ -210,14 +210,14 @@ const GeomHLine = ({
         <>
           <EventArea
             data={geomData?.filter((d) => !checkIsOutisdeDomain(d))}
-            aes={geomAes as Aes}
+            aes={geomAes as Aes<Datum>}
             x={() => 0}
             y={y}
             group="y"
             onDatumFocus={onDatumFocus}
             onClick={
               onDatumSelection
-                ? ({ d, i }: { d: unknown; i: number[] }) => {
+                ? ({ d, i }: { d: Datum[]; i: number[] }) => {
                     onDatumSelection(d, i)
                   }
                 : undefined
@@ -226,7 +226,7 @@ const GeomHLine = ({
               if (onExit) onExit()
             }}
           />
-          <Tooltip aes={geomAes as Aes} />
+          <Tooltip aes={geomAes as Aes<Datum>} />
         </>
       )}
     </>

--- a/packages/geom-hline/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-hline/src/tooltip/DefaultTooltip.tsx
@@ -7,17 +7,17 @@ import {
   themeState,
 } from '@graphique/graphique'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
   const [{ y: yLab }] = useAtom(labelsState)
   const [{ tooltip }] = useAtom(themeState)
 
   return data ? (
     <TooltipContainer>
-      {data.map((d: TooltipContent) => (
+      {data.map(d => (
         <div key={`group-tooltip-${d.label ?? ''}`}>
           <div
             style={{

--- a/packages/geom-hline/src/tooltip/Tooltip.tsx
+++ b/packages/geom-hline/src/tooltip/Tooltip.tsx
@@ -7,23 +7,24 @@ import {
   YTooltip,
   Aes,
   DataValue,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
-interface Props {
-  aes: Aes
-  group?: DataValue
+interface Props<Datum> {
+  aes: Aes<Datum>
+  group?: DataValue<Datum>
 }
 
-export const Tooltip = ({ aes, group }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, width, height, margin } = ggState || {
     width: 0,
     height: 0,
   }
 
   const [{ datum: tooltipDatum, xFormat, yFormat, measureFormat, content }] =
-    useAtom(tooltipState)
+    useAtom<TooltipProps<Datum>>(tooltipState)
 
   const datum = useMemo(() => tooltipDatum && tooltipDatum[0], [tooltipDatum])
 
@@ -49,7 +50,7 @@ export const Tooltip = ({ aes, group }: Props) => {
     [datum, group]
   )
 
-  const tooltipContents: TooltipContent[] = [
+  const tooltipContents: TooltipContent<Datum>[] = [
     {
       x: datum && aes?.x && xScale && xScale(aes.x(datum)),
       y: datum && aes?.y && yScale && yScale(aes.y(datum)),
@@ -64,9 +65,7 @@ export const Tooltip = ({ aes, group }: Props) => {
       group: thisGroup,
       label,
       formattedMeasure:
-        measureFormat &&
-        (label || thisGroup) &&
-        measureFormat(label || thisGroup),
+        measureFormat ? measureFormat(label ?? thisGroup) : undefined,
       datum,
       containerWidth: width,
     },

--- a/packages/geom-hline/src/tooltip/Tooltip.tsx
+++ b/packages/geom-hline/src/tooltip/Tooltip.tsx
@@ -66,16 +66,16 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
       label,
       formattedMeasure:
         measureFormat ? measureFormat(label ?? thisGroup) : undefined,
-      datum,
+      datum: tooltipDatum,
       containerWidth: width,
     },
   ]
 
   const tooltipValue = content
-    ? datum && <div>{content(tooltipContents)}</div>
-    : datum && <DefaultTooltip data={tooltipContents} />
+    ? tooltipDatum && <div>{content(tooltipContents)}</div>
+    : tooltipDatum && <DefaultTooltip data={tooltipContents} />
 
-  const shouldShow = datum && tooltipContents[0].y !== undefined
+  const shouldShow = tooltipDatum && tooltipContents[0].y !== undefined
 
   return shouldShow ? (
     <div>

--- a/packages/geom-label/package.json
+++ b/packages/geom-label/package.json
@@ -45,7 +45,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-label/package.json
+++ b/packages/geom-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-label",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For creating labels based on data in Graphique",
   "keywords": [
     "react",

--- a/packages/geom-label/package.json
+++ b/packages/geom-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-label",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "For creating labels based on data in Graphique",
   "keywords": [
     "react",

--- a/packages/geom-label/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-label/src/legend/AppearanceLegend.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react'
-import { useGG, themeState, IScale } from '@graphique/graphique'
+import { useGG, themeState } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 import { ColorBandLegend } from './ColorBandLegend'
@@ -14,7 +14,7 @@ export interface AppearanceLegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -23,7 +23,7 @@ export const Legend = ({
   width,
   onSelection,
 }: AppearanceLegendProps) => {
-  const { ggState } = useGG() || {}
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font }] = useAtom(themeState)
 
@@ -54,7 +54,7 @@ export const Legend = ({
         />
       ) : (
         <ColorBandLegend
-          scales={copiedScales as IScale}
+          scales={copiedScales}
           tickFormat={format}
           numTicks={numTicks}
           fontSize={fontSize}

--- a/packages/geom-label/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-label/src/legend/CategoricalLegend.tsx
@@ -9,23 +9,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface CategoricalLegendProps {
-  legendData: unknown[]
-  legendScales: IScale
+export interface CategoricalLegendProps<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: CategoricalLegendProps) => {
+}: CategoricalLegendProps<Datum>) => {
   const [isFocused, setIsFocused] = useState<string[]>(
     legendScales.groups || []
   )
@@ -37,14 +37,14 @@ export const CategoricalLegend = ({
   const legendGroups =
     ((fillDomain || strokeDomain) as string[]) || legendScales.groups
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
     setIsFocused(scales?.groups || [])
   }, [scales, data])
 
-  const getGroup: any = legendScales.groupAccessor
+  const getGroup = legendScales.groupAccessor
     ? legendScales.groupAccessor
     : () => legendScales.groups && legendScales.groups[0]
 
@@ -73,7 +73,7 @@ export const CategoricalLegend = ({
       let updatedData
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-label/src/legend/ColorBandLegend.tsx
+++ b/packages/geom-label/src/legend/ColorBandLegend.tsx
@@ -11,8 +11,8 @@ import { select } from 'd3-selection'
 import { axisBottom } from 'd3-axis'
 import { range, quantile } from 'd3-array'
 
-export interface ColorBandLegendProps {
-  scales: IScale
+export interface ColorBandLegendProps<Datum> {
+  scales: IScale<Datum>
   tickFormat?: (v: unknown, i: number) => string
   width?: number
   tickSize?: number
@@ -27,7 +27,7 @@ export interface ColorBandLegendProps {
   fontSize?: number | string
 }
 
-export const ColorBandLegend = ({
+export const ColorBandLegend = <Datum,>({
   scales,
   tickFormat,
   width = 320,
@@ -36,7 +36,7 @@ export const ColorBandLegend = ({
   margin,
   numTicks = width / 64,
   fontSize = 10,
-}: ColorBandLegendProps) => {
+}: ColorBandLegendProps<Datum>) => {
   const legendRef = useRef<SVGSVGElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const axisRef = useRef<SVGGElement | null>(null)

--- a/packages/geom-label/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-label/src/tooltip/DefaultTooltip.tsx
@@ -8,17 +8,17 @@ import {
   themeState,
 } from '@graphique/graphique'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
   const [{ x: xLab, y: yLab }] = useAtom(labelsState)
   const [{ tooltip }] = useAtom(themeState)
 
   return data ? (
     <TooltipContainer>
-      {data.map((d: TooltipContent) => {
+      {data.map(d => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div key={`group-tooltip-${d.label || formattedGroup}`}>

--- a/packages/geom-label/src/tooltip/Tooltip.tsx
+++ b/packages/geom-label/src/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   YTooltip,
   DataValue,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 import { type GeomAes } from '../types'
@@ -22,7 +23,7 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
 
   const [
     { datum: tooltipDatum, position, xFormat, yFormat, measureFormat, content },
-  ] = useAtom(tooltipState)
+  ] = useAtom<TooltipProps<Datum>>(tooltipState)
 
   const [{ x: xLab, y: yLab }] = useAtom(labelsState)
 
@@ -72,9 +73,9 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
       label,
       formattedMeasure:
         measureFormat &&
-        (label || thisGroup) &&
+        (label || String(thisGroup)) &&
         measureFormat(label || thisGroup),
-      datum,
+      datum: tooltipDatum,
       containerWidth: width,
     },
   ]

--- a/packages/geom-label/src/tooltip/Tooltip.tsx
+++ b/packages/geom-label/src/tooltip/Tooltip.tsx
@@ -11,13 +11,13 @@ import {
 import { DefaultTooltip } from './DefaultTooltip'
 import { type GeomAes } from '../types'
 
-interface Props {
-  aes: GeomAes
-  group?: DataValue
+interface Props<Datum> {
+  aes: GeomAes<Datum>
+  group?: DataValue<Datum>
 }
 
-export const Tooltip = ({ aes, group }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, height, width } = ggState || { width: 0, height: 0 }
 
   const [
@@ -37,8 +37,8 @@ export const Tooltip = ({ aes, group }: Props) => {
     return labelResolution?.given || labelResolution?.keyed
   }, [aes, datum])
 
-  const xScale: any = scales?.xScale
-  const yScale: any = scales?.yScale
+  const xScale = scales?.xScale
+  const yScale = scales?.yScale
 
   const xAdj = useMemo(
     () => (scales?.xScale.bandwidth ? scales?.xScale.bandwidth() / 2 : 0),
@@ -54,7 +54,7 @@ export const Tooltip = ({ aes, group }: Props) => {
     [datum, group]
   )
 
-  const tooltipContents: TooltipContent[] = [
+  const tooltipContents: TooltipContent<Datum>[] = [
     {
       x: datum && aes?.x && xScale && xScale(aes.x(datum)),
       y: datum && aes?.y && yScale && yScale(aes.y(datum)),

--- a/packages/geom-label/src/types/index.ts
+++ b/packages/geom-label/src/types/index.ts
@@ -1,5 +1,5 @@
 import { Aes, DataValue } from '@graphique/graphique'
 
-export type GeomAes = Omit<Aes, 'x'> & {
-  x?: DataValue
+export type GeomAes<Datum> = Omit<Aes<Datum>, 'x'> & {
+  x?: DataValue<Datum>
 }

--- a/packages/geom-line/package.json
+++ b/packages/geom-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-line",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "For line charts and other lines",
   "keywords": [
     "react",

--- a/packages/geom-line/package.json
+++ b/packages/geom-line/package.json
@@ -45,7 +45,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-line/package.json
+++ b/packages/geom-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-line",
-  "version": "1.6.8",
+  "version": "2.0.0",
   "description": "For line charts and other lines",
   "keywords": [
     "react",

--- a/packages/geom-line/src/__tests__/GeomLineLegend.test.tsx
+++ b/packages/geom-line/src/__tests__/GeomLineLegend.test.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable no-await-in-loop */
 import React from 'react'
 import { render, screen, within } from '@testing-library/react'
-import { type Stock } from '@graphique/datasets'
 import { ScaleStroke } from '@graphique/graphique'
 import { schemeDark2 } from 'd3-scale-chromatic'
 import { GeomLine, Legend } from '..'
@@ -71,7 +70,7 @@ describe("GeomLine's legend", () => {
         aes={{
           ...DEFAULT_AES,
           stroke: undefined,
-          strokeDasharray: (d: Stock) => d.symbol,
+          strokeDasharray: d => d.symbol,
         }}
       />
     )
@@ -141,7 +140,7 @@ describe("GeomLine's legend", () => {
       <GGLineLegend
         aes={{
           ...DEFAULT_AES,
-          strokeDasharray: (d: Stock) => d.symbol,
+          strokeDasharray: d => d.symbol,
         }}
       >
         <Legend ignoreDasharray />

--- a/packages/geom-line/src/__tests__/GeomLineSnapshot.test.tsx
+++ b/packages/geom-line/src/__tests__/GeomLineSnapshot.test.tsx
@@ -13,13 +13,13 @@ jest.mock('nanoid', () => ({
 
 jest.useFakeTimers()
 
-const DEFAULT_AES: Aes = {
-  x: (d: Stock) => new Date(d.date),
-  y: (d: Stock) => d.marketCap,
+const DEFAULT_AES: Aes<Stock> = {
+  x: d => new Date(d.date),
+  y: d => d.marketCap,
 }
 
 interface TestComponentProps {
-  aes?: Aes
+  aes?: Aes<Stock>
   data?: Stock[]
 }
 
@@ -43,8 +43,8 @@ describe('a line chart matches a snapshot', () => {
       <TestComponent
         aes={{
           ...DEFAULT_AES,
-          stroke: (d: Stock) => d.symbol,
-          strokeDasharray: (d: Stock) => d.symbol
+          stroke: d => d.symbol,
+          strokeDasharray: d => d.symbol
         }}
       />
     )

--- a/packages/geom-line/src/__tests__/GeomLineTooltip.test.tsx
+++ b/packages/geom-line/src/__tests__/GeomLineTooltip.test.tsx
@@ -30,7 +30,7 @@ interface Props {
   aes?: typeof DEFAULT_AES
 }
 
-const aesthetics: Aes = {
+const aesthetics: Aes<Stock> = {
   ...DEFAULT_AES,
   strokeDasharray: DEFAULT_AES.stroke
 }

--- a/packages/geom-line/src/__tests__/shared.tsx
+++ b/packages/geom-line/src/__tests__/shared.tsx
@@ -12,19 +12,20 @@ const DEFAULT_GROUP_STROKES = defaultScheme.slice(0, NUM_GROUPS)
 const DEFAULT_DASHARRAYS = defaultDasharrays.slice(0, NUM_GROUPS)
 const DEFAULT_STROKE_WIDTH = '2.5'
 const DEFAULT_SINGLE_STROKE = '#777777ee'
-const DEFAULT_AES: Aes = {
-  x: (d: Stock) => new Date(d.date),
-  y: (d: Stock) => d.marketCap,
-  stroke: (d: Stock) => d.symbol,
+const DEFAULT_AES: Aes<Stock> = {
+  x: d => new Date(d.date),
+  y: d => d.marketCap,
+  stroke: d => d.symbol,
 }
 
-interface LineProps {
-  data?: unknown[]
-  aes?: Aes
+interface LineProps<Datum> {
+  data?: Datum[]
+  aes?: Aes<Datum>
+  children?: React.ReactNode
 }
 
-const GGLine: React.FC<LineProps> = (
-  { data = stocks, aes = DEFAULT_AES, children = <GeomLine /> }
+const GGLine = (
+  { data = stocks, aes = DEFAULT_AES, children = <GeomLine /> }: LineProps<Stock>
 ) => (
   <GG
     data={data}

--- a/packages/geom-line/src/geomLine.tsx
+++ b/packages/geom-line/src/geomLine.tsx
@@ -31,9 +31,9 @@ import { useAtom } from 'jotai'
 import { LineMarker, Tooltip } from './tooltip'
 import { type GeomAes } from './types'
 
-export interface LineProps extends SVGAttributes<SVGPathElement> {
-  data?: unknown[]
-  aes?: GeomAes
+export interface LineProps<Datum> extends SVGAttributes<SVGPathElement> {
+  data?: Datum[]
+  aes?: GeomAes<Datum>
   showTooltip?: boolean
   showLineMarker?: boolean
   brushAction?: BrushAction
@@ -45,12 +45,12 @@ export interface LineProps extends SVGAttributes<SVGPathElement> {
   focusType?: 'x' | 'closest'
   focusedStyle?: CSSProperties
   unfocusedStyle?: CSSProperties
-  onDatumFocus?: (data: unknown, index: number[]) => void
-  onDatumSelection?: (data: unknown, index: number[]) => void
+  onDatumFocus?: (data: Datum[], index: number[]) => void
+  onDatumSelection?: (data: Datum, index: number[]) => void
   onExit?: () => void
 }
 
-const GeomLine = ({
+const GeomLine = <Datum,>({
   data: localData,
   aes: localAes,
   showTooltip = true,
@@ -70,8 +70,8 @@ const GeomLine = ({
   markerStroke = '#fff',
   focusType = 'x',
   ...props
-}: LineProps) => {
-  const { ggState } = useGG() || {}
+}: LineProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { data, aes, scales, copiedScales, copiedData, height, id } =
     ggState || {}
   const [theme, setTheme] = useAtom(themeState)
@@ -87,7 +87,7 @@ const GeomLine = ({
         ...localAes,
       }
     }
-    return aes as GeomAes
+    return aes as GeomAes<Datum>
   }, [aes, localAes])
 
   const allXUndefined = useMemo(() => {
@@ -194,12 +194,12 @@ const GeomLine = ({
   ])
 
   const x = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       scales?.xScale && geomAes?.x && scales.xScale(geomAes.x(d)),
     [scales, geomAes]
   )
   const y = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       geomAes?.y && scales?.yScale && scales.yScale(geomAes?.y(d)),
     [scales, geomAes]
   )
@@ -439,7 +439,7 @@ const GeomLine = ({
             data={geomData}
             aes={geomAes}
             group={focusType === 'x' ? 'x' : undefined}
-            x={(v: unknown) => x(v)}
+            x={(v: Datum) => x(v)}
             y={focusType === 'x' ? () => 0 : y}
             onMouseLeave={() => {
               if (lines) {

--- a/packages/geom-line/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-line/src/legend/AppearanceLegend.tsx
@@ -3,8 +3,7 @@ import { useGG, themeState, IScale } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface AppearanceLegendProps<Datum> {
+export interface AppearanceLegendProps {
   title?: React.ReactNode
   style?: CSSProperties
   orientation?: 'horizontal' | 'vertical'
@@ -20,7 +19,7 @@ export const Legend = <Datum,>({
   format,
   onSelection,
   ignoreDasharray = false,
-}: AppearanceLegendProps<Datum>) => {
+}: AppearanceLegendProps) => {
   const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font, geoms }] = useAtom(themeState)

--- a/packages/geom-line/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-line/src/legend/AppearanceLegend.tsx
@@ -3,24 +3,25 @@ import { useGG, themeState, IScale } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 
-export interface AppearanceLegendProps {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface AppearanceLegendProps<Datum> {
   title?: React.ReactNode
   style?: CSSProperties
   orientation?: 'horizontal' | 'vertical'
-  format?: (v: any, i: number) => string
+  format?: (v: string, i: number) => string
   onSelection?: (v: string) => void
   ignoreDasharray?: boolean
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
   format,
   onSelection,
   ignoreDasharray = false,
-}: AppearanceLegendProps) => {
-  const { ggState } = useGG() || {}
+}: AppearanceLegendProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font, geoms }] = useAtom(themeState)
 
@@ -55,7 +56,7 @@ export const Legend = ({
                     ? line.strokeScale
                     : copiedScales?.strokeScale,
                   groups: line?.usableGroups,
-                } as IScale
+                } as IScale<Datum>
               }
               labelFormat={format}
               fontSize={fontSize}

--- a/packages/geom-line/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-line/src/legend/CategoricalLegend.tsx
@@ -9,9 +9,9 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface CategoricalLegendProps {
-  legendData: unknown[]
-  legendScales: IScale
+export interface CategoricalLegendProps<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
@@ -19,7 +19,7 @@ export interface CategoricalLegendProps {
   ignoreDasharray?: boolean
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
@@ -27,7 +27,7 @@ export const CategoricalLegend = ({
   fontSize = 12,
   onSelection,
   ignoreDasharray,
-}: CategoricalLegendProps) => {
+}: CategoricalLegendProps<Datum>) => {
   const [{ geoms, defaultStroke }] = useAtom(themeState)
   const [{ domain: strokeDomain }] = useAtom(strokeScaleState)
   const [{ domain: dashArrayDomain }] = useAtom(strokeDasharrayState)
@@ -46,7 +46,7 @@ export const CategoricalLegend = ({
     geoms?.line?.usableGroups ?? []
   )
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { data } = ggState || {}
 
   const [firstRender, setFirstRender] = useState(true)
@@ -92,10 +92,10 @@ export const CategoricalLegend = ({
       onSelection(g)
     }
     if (data && updateData) {
-      let updatedData
+      let updatedData: Datum[]
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-line/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-line/src/tooltip/DefaultTooltip.tsx
@@ -7,15 +7,15 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface DefaultTooltipProps {
-  data: TooltipContent[]
+export interface DefaultTooltipProps<Datum> {
+  data: TooltipContent<Datum>[]
   hasXAxisTooltip?: boolean
 }
 
-export const DefaultTooltip = ({
+export const DefaultTooltip = <Datum,>({
   data,
   hasXAxisTooltip,
-}: DefaultTooltipProps) => {
+}: DefaultTooltipProps<Datum>) => {
   const xVal = data && data[0] ? data[0]?.formattedX : undefined
 
   const [{ tooltip }] = useAtom(themeState)
@@ -34,7 +34,7 @@ export const DefaultTooltip = ({
           {xVal}
         </div>
       )}
-      {data.map((d: TooltipContent, i: number) => {
+      {data.map((d, i) => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div

--- a/packages/geom-line/src/tooltip/LineMarker.tsx
+++ b/packages/geom-line/src/tooltip/LineMarker.tsx
@@ -9,22 +9,22 @@ import { min } from 'd3-array'
 import { useAtom } from 'jotai'
 import { type GeomAes } from '../types'
 
-export interface LineMarkerProps {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
+export interface LineMarkerProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
   markerRadius: number
   markerStroke: string
-  aes: GeomAes
+  aes: GeomAes<Datum>
 }
 
-export const LineMarker = ({
+export const LineMarker = <Datum,>({
   x,
   y,
   markerRadius,
   markerStroke,
   aes,
-}: LineMarkerProps) => {
-  const { ggState } = useGG() || {}
+}: LineMarkerProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, width, height, margin, id, scales } = ggState || {}
 
   const [{ datum }] = useAtom(tooltipState)

--- a/packages/geom-line/src/tooltip/Tooltip.tsx
+++ b/packages/geom-line/src/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
   XTooltip,
   YTooltip,
   TooltipContainer,
+  TooltipProps,
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { mean, min, max } from 'd3-array'
@@ -28,7 +29,7 @@ export const Tooltip = <Datum,>({ x, y, aes }: Props<Datum>) => {
   }
 
   const [{ datum, position, xAxis, xFormat, yFormat, content }] =
-    useAtom(tooltipState)
+    useAtom<TooltipProps<Datum>>(tooltipState)
   const [{ geoms, defaultStroke }] = useAtom(themeState)
 
   const left = useMemo(
@@ -107,10 +108,10 @@ export const Tooltip = <Datum,>({ x, y, aes }: Props<Datum>) => {
             x: xVal,
             y: aes?.y && aes.y(md),
             formattedY: aes?.y && (yFormat ? yFormat(aes.y(md)) : aes.y(md)),
-            formattedX: xFormat ? xFormat(xVal) : xVal.toString(),
+            formattedX: xFormat ? xFormat(xVal) : xVal?.toString(),
           }
         })
-    return vals as TooltipContent[]
+    return vals as TooltipContent<Datum>[]
   }, [datum, xVal, aes, yFormat, xFormat, copiedScales, geoms, defaultStroke])
 
   const tooltipValue = content ? (

--- a/packages/geom-line/src/tooltip/Tooltip.tsx
+++ b/packages/geom-line/src/tooltip/Tooltip.tsx
@@ -15,14 +15,14 @@ import { type GeomAes } from '../types'
 
 export { LineMarker } from './LineMarker'
 
-interface Props {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
-  aes: GeomAes
+interface Props<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
+  aes: GeomAes<Datum>
 }
 
-export const Tooltip = ({ x, y, aes }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ x, y, aes }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, copiedScales, width, height, margin, scales } = ggState || {
     height: 0,
   }

--- a/packages/geom-line/src/types/index.ts
+++ b/packages/geom-line/src/types/index.ts
@@ -1,5 +1,5 @@
 import { Aes, DataValue } from '@graphique/graphique'
 
-export type GeomAes = Omit<Aes, 'x' | 'fill' | 'size'> & {
-  x?: DataValue
+export type GeomAes<Datum> = Omit<Aes<Datum>, 'x' | 'fill' | 'size'> & {
+  x?: DataValue<Datum>
 }

--- a/packages/geom-point/package.json
+++ b/packages/geom-point/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-point",
-  "version": "1.4.7",
+  "version": "2.0.0",
   "description": "For points, scatterplots, and bubbles",
   "keywords": [
     "react",

--- a/packages/geom-point/package.json
+++ b/packages/geom-point/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-point",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "For points, scatterplots, and bubbles",
   "keywords": [
     "react",

--- a/packages/geom-point/package.json
+++ b/packages/geom-point/package.json
@@ -46,7 +46,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-point/src/geomPoint.tsx
+++ b/packages/geom-point/src/geomPoint.tsx
@@ -32,16 +32,16 @@ import {
 import { type GeomAes } from './types'
 import { Tooltip } from './tooltip'
 
-export interface PointProps extends SVGAttributes<SVGCircleElement> {
-  data?: unknown[]
-  aes?: GeomAes
+export interface PointProps<Datum> extends SVGAttributes<SVGCircleElement> {
+  data?: Datum[]
+  aes?: GeomAes<Datum>
   focusedStyle?: CSSProperties
   unfocusedStyle?: CSSProperties
   focusedKeys?: (string | number)[]
   showTooltip?: boolean
   brushAction?: BrushAction
-  onDatumFocus?: (data: any, index: number[]) => void
-  onDatumSelection?: (data: any, index: number[]) => void
+  onDatumFocus?: (data: Datum[], index: number[]) => void
+  onDatumSelection?: (data: Datum[], index: number[]) => void
   entrance?: 'data' | 'midpoint'
   onExit?: () => void
   fillOpacity?: number
@@ -49,7 +49,7 @@ export interface PointProps extends SVGAttributes<SVGCircleElement> {
   isClipped?: boolean
 }
 
-const GeomPoint = ({
+const GeomPoint = <Datum,>({
   data: localData,
   aes: localAes,
   focusedStyle,
@@ -66,8 +66,8 @@ const GeomPoint = ({
   isClipped = true,
   r = 3.5,
   ...props
-}: PointProps) => {
-  const { ggState } = useGG() || {}
+}: PointProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, data, aes, scales, copiedScales, height, margin } = ggState || {}
 
   const [theme, setTheme] = useAtom(themeState)
@@ -93,19 +93,19 @@ const GeomPoint = ({
   }, [aes, localAes])
 
   const group = useMemo(
-    () => geomAes && defineGroupAccessor(geomAes as Aes),
+    () => geomAes && defineGroupAccessor(geomAes as Aes<Datum>),
     [geomAes, defineGroupAccessor]
   )
 
   const positionKeyAccessor = useCallback(
-    (d: unknown) => 
+    (d: Datum) => 
       `${geomAes?.x && geomAes.x(d)}-${geomAes?.y && geomAes.y(d)}-${
         group && group(d)}` as string
     , [geomAes, group])
 
 
   const keyAccessor = useCallback(
-    (d: unknown) =>
+    (d: Datum) =>
       geomAes?.key
         ? geomAes.key(d)
         : positionKeyAccessor(d),
@@ -252,7 +252,7 @@ const GeomPoint = ({
   }
 
   const fill = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       fillColor ||
       (geomAes?.fill && copiedScales?.fillScale
         ? (copiedScales.fillScale(
@@ -264,7 +264,7 @@ const GeomPoint = ({
   )
 
   const stroke = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       strokeColor ||
       (geomAes?.stroke && copiedScales?.strokeScale
         ? (copiedScales.strokeScale(geomAes.stroke(d) as any) as
@@ -296,22 +296,22 @@ const GeomPoint = ({
 
   const x = useMemo(() => {
     if (scales?.xScale.bandwidth) {
-      return (d: unknown) =>
+      return (d: Datum) =>
         (scales?.xScale(geomAes?.x && geomAes.x(d)) || 0) +
         scales?.xScale.bandwidth() / 2 +
         0.9
     }
-    return (d: unknown) =>
+    return (d: Datum) =>
       scales?.xScale && geomAes?.x && (scales.xScale(geomAes.x(d)) || 0)
   }, [scales, geomAes])
 
   const y = useMemo(() => {
     if (scales?.yScale.bandwidth) {
-      return (d: unknown) =>
+      return (d: Datum) =>
         (scales?.yScale(geomAes?.y && geomAes.y(d)) || 0) +
         scales?.yScale.bandwidth() / 2
     }
-    return (d: unknown) =>
+    return (d: Datum) =>
       scales?.yScale && geomAes?.y && (scales.yScale(geomAes.y(d)) || 0)
   }, [scales, geomAes])
 

--- a/packages/geom-point/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-point/src/legend/AppearanceLegend.tsx
@@ -4,7 +4,8 @@ import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 import { ColorBandLegend } from './ColorBandLegend'
 
-export interface AppearanceLegendProps {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface AppearanceLegendProps<Datum> {
   title?: React.ReactNode
   style?: CSSProperties
   orientation?: 'horizontal' | 'vertical'
@@ -14,7 +15,7 @@ export interface AppearanceLegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -22,8 +23,8 @@ export const Legend = ({
   numTicks,
   width,
   onSelection,
-}: AppearanceLegendProps) => {
-  const { ggState } = useGG() || {}
+}: AppearanceLegendProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font }] = useAtom(themeState)
 
@@ -53,7 +54,7 @@ export const Legend = ({
         />
       ) : (
         <ColorBandLegend
-          scales={copiedScales as IScale}
+          scales={copiedScales as IScale<Datum>}
           tickFormat={format}
           numTicks={numTicks}
           fontSize={fontSize}

--- a/packages/geom-point/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-point/src/legend/CategoricalLegend.tsx
@@ -9,23 +9,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface CategoricalLegendProps {
-  legendData: unknown[]
-  legendScales: IScale
+export interface CategoricalLegendProps<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: CategoricalLegendProps) => {
+}: CategoricalLegendProps<Datum>) => {
   const [isFocused, setIsFocused] = useState<string[]>(
     legendScales.groups || []
   )
@@ -37,7 +37,7 @@ export const CategoricalLegend = ({
   const legendGroups =
     ((fillDomain || strokeDomain) as string[]) || legendScales.groups
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
@@ -70,10 +70,10 @@ export const CategoricalLegend = ({
       onSelection(g)
     }
     if (data && updateData) {
-      let updatedData
+      let updatedData: Datum[]
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-point/src/legend/ColorBandLegend.tsx
+++ b/packages/geom-point/src/legend/ColorBandLegend.tsx
@@ -11,8 +11,8 @@ import { select } from 'd3-selection'
 import { axisBottom } from 'd3-axis'
 import { range, quantile } from 'd3-array'
 
-export interface ColorBandLegendProps {
-  scales: IScale
+export interface ColorBandLegendProps<Datum> {
+  scales: IScale<Datum>
   tickFormat?: (v: unknown, i: number) => string
   width?: number
   tickSize?: number
@@ -27,7 +27,7 @@ export interface ColorBandLegendProps {
   fontSize?: number | string
 }
 
-export const ColorBandLegend = ({
+export const ColorBandLegend = <Datum,>({
   scales,
   tickFormat,
   width = 320,
@@ -36,7 +36,7 @@ export const ColorBandLegend = ({
   margin,
   numTicks = width / 64,
   fontSize = 10,
-}: ColorBandLegendProps) => {
+}: ColorBandLegendProps<Datum>) => {
   const legendRef = useRef<SVGSVGElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const axisRef = useRef<SVGGElement | null>(null)

--- a/packages/geom-point/src/tooltip/Tooltip.tsx
+++ b/packages/geom-point/src/tooltip/Tooltip.tsx
@@ -11,13 +11,13 @@ import {
 import { DefaultTooltip } from './DefaultTooltip'
 import { type GeomAes } from '../types'
 
-interface Props {
-  aes: GeomAes
-  group?: DataValue
+interface Props<Datum> {
+  aes: GeomAes<Datum>
+  group?: DataValue<Datum>
 }
 
-export const Tooltip = ({ aes, group }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, height, width } = ggState || { width: 0, height: 0 }
 
   const [
@@ -54,7 +54,7 @@ export const Tooltip = ({ aes, group }: Props) => {
     [datum, group]
   )
 
-  const tooltipContents: TooltipContent[] = [
+  const tooltipContents: TooltipContent<Datum>[] = [
     {
       x: datum && aes?.x && xScale && xScale(aes.x(datum)),
       y: datum && aes?.y && yScale && yScale(aes.y(datum)),

--- a/packages/geom-point/src/tooltip/Tooltip.tsx
+++ b/packages/geom-point/src/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   YTooltip,
   DataValue,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 import { type GeomAes } from '../types'
@@ -22,7 +23,7 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
 
   const [
     { datum: tooltipDatum, position, xFormat, yFormat, measureFormat, content },
-  ] = useAtom(tooltipState)
+  ] = useAtom<TooltipProps<Datum>>(tooltipState)
 
   const [{ x: xLab, y: yLab }] = useAtom(labelsState)
 
@@ -72,9 +73,9 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
       label,
       formattedMeasure:
         measureFormat &&
-        (label || thisGroup) &&
+        (label || String(thisGroup)) &&
         measureFormat(label || thisGroup),
-      datum,
+      datum: tooltipDatum,
       containerWidth: width,
     },
   ]

--- a/packages/geom-point/src/types/index.ts
+++ b/packages/geom-point/src/types/index.ts
@@ -1,5 +1,5 @@
 import { Aes, DataValue } from '@graphique/graphique'
 
-export type GeomAes = Omit<Aes, 'x'> & {
-  x?: DataValue
+export type GeomAes<Datum> = Omit<Aes<Datum>, 'x'> & {
+  x?: DataValue<Datum>
 }

--- a/packages/geom-tile/package.json
+++ b/packages/geom-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-tile",
-  "version": "0.5.4",
+  "version": "1.0.0",
   "description": "For rectangular charts like heatmaps",
   "keywords": [
     "react",

--- a/packages/geom-tile/package.json
+++ b/packages/geom-tile/package.json
@@ -46,7 +46,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-tile/package.json
+++ b/packages/geom-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-tile",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For rectangular charts like heatmaps",
   "keywords": [
     "react",

--- a/packages/geom-tile/src/geomTile.tsx
+++ b/packages/geom-tile/src/geomTile.tsx
@@ -35,7 +35,6 @@ export interface GeomTileProps<Datum> extends SVGAttributes<SVGRectElement> {
   xDomain?: unknown[]
   yDomain?: unknown[]
   showTooltip?: boolean
-  focusedDatum?: any
   onDatumFocus?: (data: Datum[], index: number[]) => void
   onDatumSelection?: (data: Datum[], index: number[]) => void
   onExit?: () => void
@@ -56,7 +55,6 @@ const GeomTile = <Datum,>({
   xPadding = 0,
   yPadding = 0,
   showTooltip = true,
-  focusedDatum,
   fillOpacity = 1,
   strokeOpacity = 1,
   ...props
@@ -332,7 +330,6 @@ const GeomTile = <Datum,>({
             y={y}
             xAdj={xBandScale.bandwidth() / 2}
             yAdj={yBandScale.bandwidth() / 2}
-            datum={focusedDatum}
             group={group}
             aes={geomAes}
           />

--- a/packages/geom-tile/src/legend/AppearanceLegend.tsx
+++ b/packages/geom-tile/src/legend/AppearanceLegend.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useEffect, useState } from 'react'
-import { useGG, themeState, IScale } from '@graphique/graphique'
+import { useGG, themeState } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 import { CategoricalLegend } from './CategoricalLegend'
 import { ColorBandLegend } from './ColorBandLegend'
@@ -14,7 +14,7 @@ export interface LegendProps {
   onSelection?: (v: string) => void
 }
 
-export const Legend = ({
+export const Legend = <Datum,>({
   title,
   style,
   orientation = 'vertical',
@@ -23,7 +23,7 @@ export const Legend = ({
   width,
   onSelection,
 }: LegendProps) => {
-  const { ggState } = useGG() || {}
+  const { ggState } = useGG<Datum>() || {}
   const { copiedScales, copiedData, aes } = ggState || {}
   const [{ font }] = useAtom(themeState)
 
@@ -60,7 +60,7 @@ export const Legend = ({
         />
       ) : (
         <ColorBandLegend
-          scales={copiedScales as IScale}
+          scales={copiedScales}
           tickFormat={format}
           numTicks={numTicks}
           fontSize={fontSize}

--- a/packages/geom-tile/src/legend/CategoricalLegend.tsx
+++ b/packages/geom-tile/src/legend/CategoricalLegend.tsx
@@ -9,23 +9,23 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-export interface Props {
-  legendData: unknown[]
-  legendScales: IScale
+export interface Props<Datum> {
+  legendData: Datum[]
+  legendScales: IScale<Datum>
   orientation?: 'vertical' | 'horizontal'
   labelFormat?: (v: any, i: number) => string
   fontSize?: string | number
   onSelection?: (v: string) => void
 }
 
-export const CategoricalLegend = ({
+export const CategoricalLegend = <Datum,>({
   legendData,
   legendScales,
   orientation = 'vertical',
   labelFormat,
   fontSize = 12,
   onSelection,
-}: Props) => {
+}: Props<Datum>) => {
   const [isFocused, setIsFocused] = useState<string[]>(
     legendScales.groups || []
   )
@@ -37,7 +37,7 @@ export const CategoricalLegend = ({
   const legendGroups =
     ((fillDomain || strokeDomain) as string[]) || legendScales.groups
 
-  const { ggState, updateData } = useGG() || {}
+  const { ggState, updateData } = useGG<Datum>() || {}
   const { scales, data } = ggState || {}
 
   useEffect(() => {
@@ -73,7 +73,7 @@ export const CategoricalLegend = ({
       let updatedData
       if (includedGroups.includes(g)) {
         if (includedGroups.length === 1) {
-          updatedData = legendData as unknown[]
+          updatedData = legendData
         } else {
           updatedData = data.filter((d) => getGroup(d) !== g)
         }

--- a/packages/geom-tile/src/legend/ColorBandLegend.tsx
+++ b/packages/geom-tile/src/legend/ColorBandLegend.tsx
@@ -11,8 +11,8 @@ import { select } from 'd3-selection'
 import { axisBottom } from 'd3-axis'
 import { range, quantile } from 'd3-array'
 
-export interface ColorBandLegendProps {
-  scales: IScale
+export interface ColorBandLegendProps<Datum> {
+  scales: IScale<Datum>
   tickFormat?: (v: unknown, i: number) => string
   width?: number
   tickSize?: number
@@ -27,7 +27,7 @@ export interface ColorBandLegendProps {
   fontSize?: number | string
 }
 
-export const ColorBandLegend = ({
+export const ColorBandLegend = <Datum,>({
   scales,
   tickFormat,
   width = 320,
@@ -36,7 +36,7 @@ export const ColorBandLegend = ({
   margin,
   numTicks = width / 64,
   fontSize = 10,
-}: ColorBandLegendProps) => {
+}: ColorBandLegendProps<Datum>) => {
   const legendRef = useRef<SVGSVGElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const axisRef = useRef<SVGGElement | null>(null)

--- a/packages/geom-tile/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-tile/src/tooltip/DefaultTooltip.tsx
@@ -8,17 +8,17 @@ import {
 } from '@graphique/graphique'
 import { useAtom } from 'jotai'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
   const [{ x: xLab, y: yLab }] = useAtom(labelsState)
   const [{ tooltip }] = useAtom(themeState)
 
   return data ? (
     <TooltipContainer>
-      {data.map((d: TooltipContent) => {
+      {data.map(d => {
         const formattedGroup = formatMissing(d.group)
         return (
           <div key={`group-tooltip-${d.label || formattedGroup}`}>

--- a/packages/geom-tile/src/tooltip/index.tsx
+++ b/packages/geom-tile/src/tooltip/index.tsx
@@ -10,17 +10,17 @@ import {
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
-export interface TooltipProps {
-  x: (d: unknown) => number | undefined
-  y: (d: unknown) => number | undefined
+export interface TooltipProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
   xAdj: number
   yAdj: number
-  datum?: any
-  group: DataValue
-  aes: Aes
+  datum?: Datum[]
+  group: DataValue<Datum>
+  aes: Aes<Datum>
 }
 
-export const Tooltip = ({
+export const Tooltip = <Datum,>({
   x,
   y,
   xAdj,
@@ -28,8 +28,8 @@ export const Tooltip = ({
   datum,
   group,
   aes,
-}: TooltipProps) => {
-  const { ggState } = useGG() || {}
+}: TooltipProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, height, width } = ggState || { width: 0, height: 0 }
 
   const [
@@ -60,7 +60,7 @@ export const Tooltip = ({
     [label]
   )
 
-  const tooltipContents: TooltipContent[] = [
+  const tooltipContents: TooltipContent<Datum>[] = [
     {
       x: thisDatum && (x(thisDatum) as number),
       y: thisDatum && (y(thisDatum) as number),

--- a/packages/geom-tile/src/tooltip/index.tsx
+++ b/packages/geom-tile/src/tooltip/index.tsx
@@ -7,15 +7,15 @@ import {
   YTooltip,
   Aes,
   DataValue,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
-export interface TooltipProps<Datum> {
+interface Props<Datum> {
   x: (d: Datum) => number | undefined
   y: (d: Datum) => number | undefined
   xAdj: number
   yAdj: number
-  datum?: Datum[]
   group: DataValue<Datum>
   aes: Aes<Datum>
 }
@@ -25,21 +25,17 @@ export const Tooltip = <Datum,>({
   y,
   xAdj,
   yAdj,
-  datum,
   group,
   aes,
-}: TooltipProps<Datum>) => {
+}: Props<Datum>) => {
   const { ggState } = useGG<Datum>() || {}
   const { id, height, width } = ggState || { width: 0, height: 0 }
 
   const [
     { datum: tooltipDatum, position, xFormat, yFormat, measureFormat, content },
-  ] = useAtom(tooltipState)
+  ] = useAtom<TooltipProps<Datum>>(tooltipState)
 
-  const thisDatum = useMemo(
-    () => datum ?? (tooltipDatum && tooltipDatum[0]),
-    [tooltipDatum]
-  )
+  const thisDatum = useMemo(() => tooltipDatum && tooltipDatum[0], [tooltipDatum])
 
   const label = useMemo(() => {
     const labelResolution = {
@@ -76,9 +72,9 @@ export const Tooltip = <Datum,>({
       label: thisLabel,
       formattedMeasure:
         measureFormat &&
-        (thisLabel || thisGroup) &&
+        (thisLabel || String(thisGroup)) &&
         measureFormat(thisLabel || thisGroup),
-      datum: thisDatum,
+      datum: tooltipDatum,
       containerWidth: width,
     },
   ]

--- a/packages/geom-vline/package.json
+++ b/packages/geom-vline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-vline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For drawing vertical lines (usually used as markers)",
   "keywords": [
     "react",

--- a/packages/geom-vline/package.json
+++ b/packages/geom-vline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/geom-vline",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "For drawing vertical lines (usually used as markers)",
   "keywords": [
     "react",

--- a/packages/geom-vline/package.json
+++ b/packages/geom-vline/package.json
@@ -47,7 +47,7 @@
     "react-move": "^6.5.0"
   },
   "peerDependencies": {
-    "@graphique/graphique": ">=1",
+    "@graphique/graphique": ">=2",
     "react": ">=16",
     "react-dom": ">=16"
   },

--- a/packages/geom-vline/src/__tests__/GeomVLineBasics.test.tsx
+++ b/packages/geom-vline/src/__tests__/GeomVLineBasics.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { render, screen, act } from '@testing-library/react'
-import { Stock, penguins } from '@graphique/datasets'
+import { penguins } from '@graphique/datasets'
 import {
   GGVLine,
   NUM_GROUPS,
   DEFAULT_GROUP_STROKES,
   DEFAULT_AES,
   DEFAULT_STROKE_WIDTH,
-} from "./shared"
-import { beakLengthsBySpecies, type PenguinSummary } from './__data__/penguinSummaries'
+} from './shared'
+import { beakLengthsBySpecies } from './__data__/penguinSummaries'
 import { GeomVLine } from '../geomVLine'
 import { aaplMarketcap } from './__data__/aaplMarketcap'
 
@@ -20,7 +20,7 @@ describe('vertical line basics with GeomVLine', () => {
       <GGVLine
         aes={{
           ...DEFAULT_AES,
-          x: (d: PenguinSummary) => d.count!
+          x: d => d.count!
         }}
       />
     )
@@ -50,8 +50,8 @@ describe('vertical line basics with GeomVLine', () => {
       <GGVLine
         data={aaplMarketcap}
         aes={{
-          x: (d: Stock) => new Date(d.date),
-          y: (d: Stock) => d.marketCap,
+          x: d => new Date(d.date),
+          y: d => d.marketCap,
         }}
       />
     )
@@ -72,8 +72,8 @@ describe('vertical line basics with GeomVLine', () => {
       <GGVLine
         data={aaplMarketcap}
         aes={{
-          x: (d: Stock) => new Date(d.date),
-          y: (d: Stock) => d.marketCap,
+          x: d => new Date(d.date),
+          y: d => d.marketCap,
         }}
       >
         <GeomVLine data={[aaplMarketcap[45]]} />
@@ -97,7 +97,7 @@ describe('vertical line basics with GeomVLine', () => {
         <GeomVLine
           data={beakLengthsBySpecies}
           aes={{
-            x: (d: PenguinSummary) => d.count!
+            x: d => d.count!
           }}
         />
       </GGVLine>

--- a/packages/geom-vline/src/__tests__/GeomVLineSnapshot.test.tsx
+++ b/packages/geom-vline/src/__tests__/GeomVLineSnapshot.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Penguin, Stock, penguins } from '@graphique/datasets'
+import { penguins } from '@graphique/datasets'
 import { act, screen } from '@testing-library/react'
 import { DEFAULT_AES, GGVLine, setup } from './shared'
-import { beakLengthsBySpecies, type PenguinSummary } from './__data__/penguinSummaries'
+import { beakLengthsBySpecies } from './__data__/penguinSummaries'
 import { GeomVLine } from '../geomVLine'
 import { GeomPoint } from '../../../geom-point'
 import { aaplMarketcap } from './__data__/aaplMarketcap'
@@ -21,7 +21,7 @@ describe('a chart with vertical lines matches a snapshot', () => {
         <GeomVLine
           data={beakLengthsBySpecies}
           aes={{
-            x: (d: PenguinSummary) => d.count!,
+            x: d => d.count!,
           }}
           strokeDasharray='2,1'
         />
@@ -39,13 +39,13 @@ describe('a chart with vertical lines matches a snapshot', () => {
         data={penguins.filter(d => DEFAULT_AES.x(d) && DEFAULT_AES?.y?.(d))}
         aes={{
           ...DEFAULT_AES,
-          fill: (d: Penguin) => d.species
+          fill: d => d.species
         }}
       >
         <GeomVLine
           data={beakLengthsBySpecies}
           aes={{
-            x: (d: PenguinSummary) => d.count!,
+            x: d => d.count!,
           }}
           strokeDasharray='2,1'
           showTooltip={false}
@@ -69,8 +69,8 @@ describe('a chart with vertical lines matches a snapshot', () => {
       <GGVLine
         data={aaplMarketcap}
         aes={{
-          x: (d: Stock) => new Date(d.date),
-          y: (d: Stock) => d.marketCap
+          x: d => new Date(d.date),
+          y: d => d.marketCap
         }}
       >
         <GeomVLine

--- a/packages/geom-vline/src/__tests__/shared.tsx
+++ b/packages/geom-vline/src/__tests__/shared.tsx
@@ -11,19 +11,24 @@ const NUM_GROUPS = GROUPS.length
 const DEFAULT_GROUP_STROKES = defaultScheme.slice(0, NUM_GROUPS)
 const DEFAULT_STROKE_WIDTH = '1.5'
 const DEFAULT_SINGLE_STROKE = '#777777ee'
-const DEFAULT_AES: Aes = {
-  x: (d: PenguinSummary) => d.beakLength,
-  y: (d: PenguinSummary) => d.flipperLength,
-  stroke: (d: PenguinSummary) => d.species,
+const DEFAULT_AES: Aes<PenguinSummary> = {
+  x: d => d.beakLength,
+  y: d => d.flipperLength,
+  stroke: d => d.species,
 }
 
-interface VLineProps {
-  data?: unknown[]
-  aes?: Aes
+interface VLineProps<Datum> {
+  data?: Datum[]
+  aes?: Aes<Datum>
+  children?: React.ReactNode
 }
 
-const GGVLine: React.FC<VLineProps> = (
-  { data = beakLengthsBySpecies, aes = DEFAULT_AES, children = <GeomVLine /> }
+const GGVLine = <Datum,>(
+  {
+    data = beakLengthsBySpecies as Datum[],
+    aes = DEFAULT_AES as Aes<Datum>,
+    children = <GeomVLine />,
+  }: VLineProps<Datum>
 ) => (
   <GG
     data={data}

--- a/packages/geom-vline/src/geomVLine.tsx
+++ b/packages/geom-vline/src/geomVLine.tsx
@@ -130,12 +130,12 @@ const GeomVLine = <Datum,>({
   )
 
   const keyAccessor = useMemo(
-    () => (d: Datum) =>
+    () => (d: Datum, i: number) =>
       geomAes?.key
         ? geomAes.key(d)
         : (`${geomAes?.x && geomAes.x(d)}-${geomAes?.y && geomAes.y(d)}-${
             scales?.groupAccessor && scales.groupAccessor(d)
-          }` as string),
+          }-${i}` as string),
     [geomAes, scales]
   )
 
@@ -149,7 +149,7 @@ const GeomVLine = <Datum,>({
             !firstRender &&
             isVisible && (
               <NodeGroup
-                data={[...(geomData as [])]}
+                data={[...geomData]}
                 keyAccessor={keyAccessor}
                 start={(d) => ({
                   x1: x(d),

--- a/packages/geom-vline/src/geomVLine.tsx
+++ b/packages/geom-vline/src/geomVLine.tsx
@@ -20,25 +20,25 @@ import { easeCubic } from 'd3-ease'
 import { interpolate } from 'd3-interpolate'
 import { Tooltip } from './tooltip'
 
-type GeomAes = Omit<Aes, 'x' | 'y' | 'fill' | 'size'> & {
-  x?: DataValue
+type GeomAes<Datum> = Omit<Aes<Datum>, 'x' | 'y' | 'fill' | 'size'> & {
+  x?: DataValue<Datum>
 }
 
 const DEFAULT_TICK_SIZE = 6
 
-export interface GeomVLineProps extends SVGAttributes<SVGLineElement> {
-  data?: unknown[]
-  aes?: GeomAes
+export interface GeomVLineProps<Datum> extends SVGAttributes<SVGLineElement> {
+  data?: Datum[]
+  aes?: GeomAes<Datum>
   focusedStyle?: CSSProperties
   unfocusedStyle?: CSSProperties
   showTooltip?: boolean
-  onDatumFocus?: (data: unknown, index: number[]) => void
-  onDatumSelection?: (data: unknown, index: number[]) => void
+  onDatumFocus?: (data: Datum[], index: number[]) => void
+  onDatumSelection?: (data: Datum[], index: number[]) => void
   onExit?: () => void
   strokeOpacity?: number
 }
 
-const GeomVLine = ({
+const GeomVLine = <Datum,>({
   data: localData,
   aes: localAes,
   focusedStyle,
@@ -50,8 +50,8 @@ const GeomVLine = ({
   strokeWidth = 1.5,
   strokeOpacity = 1,
   ...props
-}: GeomVLineProps) => {
-  const { ggState } = useGG() || {}
+}: GeomVLineProps<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { data, aes, scales, copiedScales, height, margin } = ggState || {}
 
   const geomData = localData || data
@@ -100,7 +100,7 @@ const GeomVLine = ({
   }, [setTheme, strokeColor, strokeOpacity, strokeWidth, props.style])
 
   const stroke = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       strokeColor ||
       (geomAes?.stroke && copiedScales?.strokeScale
         ? (copiedScales.strokeScale(geomAes.stroke(d) as any) as
@@ -111,13 +111,13 @@ const GeomVLine = ({
   )
 
   const x = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       scales?.xScale && geomAes?.x && scales.xScale(geomAes.x(d)),
     [scales, geomAes]
   )
 
   const checkIsOutisdeDomain = useMemo(
-    () => (d: unknown) => {
+    () => (d: Datum) => {
       const domain = scales?.xScale && scales.xScale.domain()
 
       return (
@@ -130,7 +130,7 @@ const GeomVLine = ({
   )
 
   const keyAccessor = useMemo(
-    () => (d: unknown) =>
+    () => (d: Datum) =>
       geomAes?.key
         ? geomAes.key(d)
         : (`${geomAes?.x && geomAes.x(d)}-${geomAes?.y && geomAes.y(d)}-${
@@ -220,14 +220,14 @@ const GeomVLine = ({
         <>
           <EventArea
             data={geomData?.filter((d) => !checkIsOutisdeDomain(d))}
-            aes={geomAes as Aes}
+            aes={geomAes}
             x={x}
             y={() => 0}
             group="x"
             onDatumFocus={onDatumFocus}
             onClick={
               onDatumSelection
-                ? ({ d, i }: { d: unknown; i: number[] }) => {
+                ? ({ d, i }: { d: Datum[]; i: number[] }) => {
                     onDatumSelection(d, i)
                   }
                 : undefined
@@ -236,7 +236,7 @@ const GeomVLine = ({
               if (onExit) onExit()
             }}
           />
-          <Tooltip aes={geomAes as Aes} />
+          <Tooltip aes={geomAes} />
         </>
       )}
     </>

--- a/packages/geom-vline/src/tooltip/DefaultTooltip.tsx
+++ b/packages/geom-vline/src/tooltip/DefaultTooltip.tsx
@@ -7,17 +7,17 @@ import {
   themeState,
 } from '@graphique/graphique'
 
-interface Props {
-  data: TooltipContent[]
+interface Props<Datum> {
+  data: TooltipContent<Datum>[]
 }
 
-export const DefaultTooltip = ({ data }: Props) => {
+export const DefaultTooltip = <Datum,>({ data }: Props<Datum>) => {
   const [{ x: xLab }] = useAtom(labelsState)
   const [{ tooltip }] = useAtom(themeState)
 
   return data ? (
     <TooltipContainer>
-      {data.map((d: TooltipContent) => (
+      {data.map(d => (
         <div key={`group-tooltip-${d.label ?? ''}`}>
           <div
             style={{

--- a/packages/geom-vline/src/tooltip/Tooltip.tsx
+++ b/packages/geom-vline/src/tooltip/Tooltip.tsx
@@ -10,13 +10,13 @@ import {
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
-interface Props {
-  aes: Aes
-  group?: DataValue
+interface Props<Datum> {
+  aes: Aes<Datum>
+  group?: DataValue<Datum>
 }
 
-export const Tooltip = ({ aes, group }: Props) => {
-  const { ggState } = useGG() || {}
+export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
+  const { ggState } = useGG<Datum>() || {}
   const { id, scales, height, width } = ggState || {
     width: 0,
     height: 0,
@@ -49,7 +49,7 @@ export const Tooltip = ({ aes, group }: Props) => {
     [datum, group]
   )
 
-  const tooltipContents: TooltipContent[] = [
+  const tooltipContents: TooltipContent<Datum>[] = [
     {
       x: datum && aes?.x && xScale && xScale(aes.x(datum)),
       y: datum && aes?.y && yScale && yScale(aes.y(datum)),

--- a/packages/geom-vline/src/tooltip/Tooltip.tsx
+++ b/packages/geom-vline/src/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
   YTooltip,
   Aes,
   DataValue,
+  TooltipProps,
 } from '@graphique/graphique'
 import { DefaultTooltip } from './DefaultTooltip'
 
@@ -23,7 +24,7 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
   }
 
   const [{ datum: tooltipDatum, xFormat, yFormat, measureFormat, content }] =
-    useAtom(tooltipState)
+    useAtom<TooltipProps<Datum>>(tooltipState)
 
   const datum = useMemo(() => tooltipDatum && tooltipDatum[0], [tooltipDatum])
 
@@ -65,18 +66,18 @@ export const Tooltip = <Datum,>({ aes, group }: Props<Datum>) => {
       label,
       formattedMeasure:
         measureFormat &&
-        (label || thisGroup) &&
+        (label || String(thisGroup)) &&
         measureFormat(label || thisGroup),
-      datum,
+      datum: tooltipDatum,
       containerWidth: width,
     },
   ]
 
   const tooltipValue = content
-    ? datum && <div>{content(tooltipContents)}</div>
-    : datum && <DefaultTooltip data={tooltipContents} />
+    ? tooltipDatum && <div>{content(tooltipContents)}</div>
+    : tooltipDatum && <DefaultTooltip data={tooltipContents} />
 
-  const shouldShow = datum && tooltipContents[0].x !== undefined
+  const shouldShow = tooltipDatum && tooltipContents[0].x !== undefined
 
   return shouldShow ? (
     <div>

--- a/packages/graphique/package-lock.json
+++ b/packages/graphique/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@graphique/graphique",
-  "version": "1.6.9",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@graphique/graphique",
-      "version": "1.6.9",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",

--- a/packages/graphique/package-lock.json
+++ b/packages/graphique/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@graphique/graphique",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@graphique/graphique",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",

--- a/packages/graphique/package-lock.json
+++ b/packages/graphique/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@graphique/graphique",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@graphique/graphique",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.0.1",

--- a/packages/graphique/package.json
+++ b/packages/graphique/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/graphique",
-  "version": "1.6.9",
+  "version": "2.0.0",
   "description": "A data visualization system for React based on the Grammar of Graphics.",
   "keywords": [
     "react",

--- a/packages/graphique/package.json
+++ b/packages/graphique/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/graphique",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A data visualization system for React based on the Grammar of Graphics.",
   "keywords": [
     "react",

--- a/packages/graphique/package.json
+++ b/packages/graphique/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphique/graphique",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A data visualization system for React based on the Grammar of Graphics.",
   "keywords": [
     "react",

--- a/packages/graphique/src/atoms/theme.ts
+++ b/packages/graphique/src/atoms/theme.ts
@@ -29,9 +29,9 @@ interface AreaProps<Datum> extends PointThemeProps<Datum> {
   /** controls how to draw the area */
   position?: AreaPositions
   /** a functional mapping to `data` representing an initial **y** value */
-  y0?: DataValue<Datum>
+  y0?: (d: Datum) => number | undefined
   /** a functional mapping to `data` representing a secondary **y** value */
-  y1?: DataValue<Datum>
+  y1?: (d: Datum) => number | undefined
 }
 
 interface HistProps {

--- a/packages/graphique/src/atoms/theme.ts
+++ b/packages/graphique/src/atoms/theme.ts
@@ -1,7 +1,7 @@
 import { atom } from "jotai"
 import type { DataValue, VisualEncodingTypes } from "../gg"
 
-interface PointThemeProps {
+interface PointThemeProps<Datum> {
   fillOpacity?: number | string
   stroke?: string
   strokeWidth?: number | string
@@ -12,7 +12,7 @@ interface PointThemeProps {
   fillScale?: VisualEncodingTypes
   strokeScale?: VisualEncodingTypes
   usableGroups?: string[]
-  groupAccessor?: DataValue
+  groupAccessor?: DataValue<Datum>
   size?: (d: any) => number | null | undefined
 }
 
@@ -21,40 +21,40 @@ export type BarColPositions = SharedPositions | 'dodge'
 export type AreaPositions = SharedPositions
   //  | 'stream'
 
-interface BarColProps extends PointThemeProps {
+interface BarColProps<Datum> extends PointThemeProps<Datum> {
   position?: BarColPositions
 }
 
-interface AreaProps extends PointThemeProps {
+interface AreaProps<Datum> extends PointThemeProps<Datum> {
   /** controls how to draw the area */
   position?: AreaPositions
   /** a functional mapping to `data` representing an initial **y** value */
-  y0?: DataValue
+  y0?: DataValue<Datum>
   /** a functional mapping to `data` representing a secondary **y** value */
-  y1?: DataValue
+  y1?: DataValue<Datum>
 }
 
 interface HistProps {
   binWidth?: number
 }
 
-export interface ThemeProps {
+export interface ThemeProps<Datum> {
   titleColor?: string
   markerStroke?: string
   defaultStroke?: string
   defaultFill?: string
   geoms?: {
-    point?: PointThemeProps
-    line?: PointThemeProps
-    vline?: PointThemeProps
-    hline?: PointThemeProps
-    smooth?: PointThemeProps
-    tile?: PointThemeProps
-    bar?: BarColProps
-    col?: BarColProps
+    point?: PointThemeProps<Datum>
+    line?: PointThemeProps<Datum>
+    vline?: PointThemeProps<Datum>
+    hline?: PointThemeProps<Datum>
+    smooth?: PointThemeProps<Datum>
+    tile?: PointThemeProps<Datum>
+    bar?: BarColProps<Datum>
+    col?: BarColProps<Datum>
     histogram?: HistProps
-    area?: AreaProps
-    label?: PointThemeProps
+    area?: AreaProps<Datum>
+    label?: PointThemeProps<Datum>
   }
   font?: {
     family?: string
@@ -135,9 +135,9 @@ export interface ThemeProps {
   animationDuration?: number
 }
 
-export const pointThemeState = atom<PointThemeProps>({})
+export const pointThemeState = atom<PointThemeProps<any>>({})
 
-export const themeState = atom<ThemeProps>({
+export const themeState = atom<ThemeProps<any>>({
   // titleColor: "#222",
   markerStroke: "#fff",
   defaultStroke: "#777777ee",

--- a/packages/graphique/src/atoms/tooltip.ts
+++ b/packages/graphique/src/atoms/tooltip.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import { atom } from 'jotai'
 import { isDate, formatDate } from '../util/dates'
 
-export interface TooltipContent {
+export interface TooltipContent<Datum> {
   label?: string
   group?: string | number | Date | null
   mark?: JSX.Element
@@ -11,13 +11,13 @@ export interface TooltipContent {
   formattedX?: string
   formattedY?: string
   formattedMeasure?: string
-  datum: any
+  datum?: Datum
   containerWidth: number
   xLab?: string
   yLab?: string
 }
 
-export interface TooltipProps {
+export interface TooltipProps<Datum> {
   x0?: any
   y0?: any
   left?: number
@@ -30,9 +30,9 @@ export interface TooltipProps {
   xFormat?: (d: unknown) => string
   yFormat?: (d: unknown) => string
   measureFormat?: (d: unknown) => string
-  content?: (value: TooltipContent[]) => React.ReactNode | undefined
-  xAxis?: ((x: string | number | Date) => React.ReactNode) | boolean
-  datum?: any[]
+  content?: (value: TooltipContent<Datum>[]) => React.ReactNode | undefined
+  xAxis?: ((x?: string | number | Date | null) => React.ReactNode) | boolean
+  datum?: Datum[]
 }
 
 const defaultDataFormatter = (v: unknown) => {
@@ -42,7 +42,7 @@ const defaultDataFormatter = (v: unknown) => {
   return v as any
 }
 
-export const tooltipState = atom<TooltipProps>({
+export const tooltipState = atom<TooltipProps<any>>({
   position: 'data',
   keepInParent: true,
   xFormat: defaultDataFormatter,

--- a/packages/graphique/src/atoms/tooltip.ts
+++ b/packages/graphique/src/atoms/tooltip.ts
@@ -11,7 +11,7 @@ export interface TooltipContent<Datum> {
   formattedX?: string
   formattedY?: string
   formattedMeasure?: string
-  datum?: Datum
+  datum?: Datum[]
   containerWidth: number
   xLab?: string
   yLab?: string
@@ -30,7 +30,7 @@ export interface TooltipProps<Datum> {
   xFormat?: (d: unknown) => string
   yFormat?: (d: unknown) => string
   measureFormat?: (d: unknown) => string
-  content?: (value: TooltipContent<Datum>[]) => React.ReactNode | undefined
+  content?: (value?: TooltipContent<Datum>[]) => React.ReactNode | undefined
   xAxis?: ((x?: string | number | Date | null) => React.ReactNode) | boolean
   datum?: Datum[]
 }

--- a/packages/graphique/src/gg/GG.tsx
+++ b/packages/graphique/src/gg/GG.tsx
@@ -10,7 +10,7 @@ import { generateID } from '../util'
 import { GGBase } from './GGBase'
 import type { RootGGProps } from './types/GG'
 
-export const GG = ({ children, ...props }: RootGGProps) => {
+export const GG = <Datum,>({ children, ...props }: RootGGProps<Datum>) => {
   const { data, aes, width, height, margin, isContainerWidth } = { ...props }
   const ggRef = useRef<HTMLDivElement>(null)
 
@@ -43,7 +43,7 @@ export const GG = ({ children, ...props }: RootGGProps) => {
     <div ref={ggRef}>
       <Provider>
         <GGBase
-          data={data.map((d: any, i) => ({
+          data={data.map((d: Datum, i) => ({
             ...d,
             gg_gen_index: i,
           }))}

--- a/packages/graphique/src/gg/GGBase.tsx
+++ b/packages/graphique/src/gg/GGBase.tsx
@@ -23,7 +23,7 @@ import {
   strokeDasharrayState,
 } from '../atoms'
 
-export interface ContextProps {
+export interface ContextProps<Datum> {
   ggState: {
     id?: string
     width: number
@@ -34,18 +34,18 @@ export interface ContextProps {
       bottom: number
       left: number
     }
-    data: unknown[]
-    copiedData: unknown[]
-    aes: Aes
-    copiedScales: IScale
-    scales: IScale
+    data: Datum[]
+    copiedData: Datum[]
+    aes: Aes<Datum>
+    copiedScales: IScale<Datum>
+    scales: IScale<Datum>
   }
-  updateData: (newData: unknown[]) => void
+  updateData: (newData: Datum[]) => void
 }
 
-const GGglobalCtx = createContext<ContextProps | undefined>(undefined)
+const GGglobalCtx = createContext<ContextProps<any> | undefined>(undefined)
 
-export const GGBase = ({
+export const GGBase = <Datum,>({
   data,
   aes,
   width = 500,
@@ -53,7 +53,7 @@ export const GGBase = ({
   margin: suppliedMargin,
   id,
   children,
-}: GGProps) => {
+}: GGProps<Datum>) => {
   const [labels] = useAtom(labelsState)
   const [{ font, titleColor, axis, axisX, axisY }] = useAtom(themeState)
   const [xScale] = useAtom(xScaleState)
@@ -93,12 +93,12 @@ export const GGBase = ({
   const geomZeroXBaseLines: (boolean | undefined)[] = []
   const geomZeroYBaseLines: (boolean | undefined)[] = []
   const geomAesXs = []
-  const geomAesYs: DataValue[] = []
-  const geomAesY0s: DataValue[] = []
-  const geomAesY1s: DataValue[] = []
-  const geomGroupAccessors: DataValue[] = []
-  const geomAesStrokes: DataValue[] = []
-  const geomAesFills: DataValue[] = []
+  const geomAesYs: DataValue<Datum>[] = []
+  const geomAesY0s: DataValue<Datum>[] = []
+  const geomAesY1s: DataValue<Datum>[] = []
+  const geomGroupAccessors: DataValue<Datum>[] = []
+  const geomAesStrokes: DataValue<Datum>[] = []
+  const geomAesFills: DataValue<Datum>[] = []
 
   geoms.forEach((g: any) => {
     const geomProps = g.props
@@ -295,4 +295,4 @@ export const GGBase = ({
   ) : null
 }
 
-export const useGG = () => useContext(GGglobalCtx)
+export const useGG = <Datum,>() => useContext(GGglobalCtx as React.Context<ContextProps<Datum>>)

--- a/packages/graphique/src/gg/axes/XAxis.tsx
+++ b/packages/graphique/src/gg/axes/XAxis.tsx
@@ -2,17 +2,17 @@ import React, { useRef, useEffect, useState, useMemo } from 'react'
 import { axisBottom, AxisScale } from 'd3-axis'
 import { select } from 'd3-selection'
 import { useAtom } from 'jotai'
-import { labelsState, themeState, xScaleState, tooltipState } from '../../atoms'
+import { labelsState, themeState, xScaleState, tooltipState, TooltipProps } from '../../atoms'
 import { defaultGridOpacity, defaultAnimationDuration } from './constants'
 import { Aes } from '../types'
 import { IScale } from '../../util/autoScale'
 
-export interface XAxisProps {
+export interface XAxisProps<Datum> {
   ggState: {
     id: string | undefined
-    copiedData: unknown[]
-    data: unknown[]
-    aes: Aes
+    copiedData: Datum[]
+    data: Datum[]
+    aes: Aes<Datum>
     width: number
     height: number
     margin: {
@@ -21,13 +21,13 @@ export interface XAxisProps {
       bottom: number
       left: number
     }
-    copiedScales: IScale
-    scales: IScale
+    copiedScales: IScale<Datum>
+    scales: IScale<Datum>
   }
   animate?: boolean
 }
 
-export const XAxis = ({ ggState, animate = true }: XAxisProps) => {
+export const XAxis = <Datum,>({ ggState, animate = true }: XAxisProps<Datum>) => {
   const [{ axis: axisTheme, axisX, grid: gridTheme, font, animationDuration }] =
     useAtom(themeState)
   const { aes, width, margin, height, scales } = ggState || {
@@ -41,7 +41,7 @@ export const XAxis = ({ ggState, animate = true }: XAxisProps) => {
     },
   }
   const scale = scales?.xScale as AxisScale<number | string | Date>
-  const [{ datum }] = useAtom(tooltipState)
+  const [{ datum }] = useAtom<TooltipProps<Datum>>(tooltipState)
   const [labels] = useAtom(labelsState)
   const [{ format, numTicks, highlightOnFocus, className }] =
     useAtom(xScaleState)

--- a/packages/graphique/src/gg/axes/YAxis.tsx
+++ b/packages/graphique/src/gg/axes/YAxis.tsx
@@ -3,17 +3,17 @@ import { axisLeft, AxisScale } from 'd3-axis'
 import { select } from 'd3-selection'
 import 'd3-transition'
 import { useAtom } from 'jotai'
-import { themeState, yScaleState, tooltipState } from '../../atoms'
+import { themeState, yScaleState, tooltipState, TooltipProps } from '../../atoms'
 import { defaultGridOpacity, defaultAnimationDuration } from './constants'
 import { Aes } from '../types'
 import { IScale } from '../../util/autoScale'
 
-export interface YAxisProps {
+export interface YAxisProps<Datum> {
   ggState: {
     id: string | undefined
-    copiedData: unknown[]
-    data: unknown[]
-    aes: Aes
+    copiedData: Datum[]
+    data: Datum[]
+    aes: Aes<Datum>
     width: number
     height: number
     margin: {
@@ -22,13 +22,13 @@ export interface YAxisProps {
       bottom: number
       left: number
     }
-    copiedScales: IScale
-    scales: IScale
+    copiedScales: IScale<Datum>
+    scales: IScale<Datum>
   }
   animate?: boolean
 }
 
-export const YAxis = ({ ggState, animate = true }: YAxisProps) => {
+export const YAxis = <Datum,>({ ggState, animate = true }: YAxisProps<Datum>) => {
   const [{ axis: axisTheme, axisY, grid: gridTheme, font, animationDuration }] =
     useAtom(themeState)
   const { aes, height, width, margin, scales } = ggState || {
@@ -42,7 +42,7 @@ export const YAxis = ({ ggState, animate = true }: YAxisProps) => {
     },
   }
   const scale = scales?.yScale as AxisScale<number | string | Date>
-  const [{ datum }] = useAtom(tooltipState)
+  const [{ datum }] = useAtom<TooltipProps<Datum>>(tooltipState)
 
   const [{ format, numTicks, highlightOnFocus, className }] =
     useAtom(yScaleState)

--- a/packages/graphique/src/gg/theme/index.tsx
+++ b/packages/graphique/src/gg/theme/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useAtom } from 'jotai'
 import { themeState, ThemeProps } from '../../atoms'
 
-export const Theme = ({
+export const Theme = <Datum,>({
   titleColor,
   markerStroke,
   defaultStroke,
@@ -15,7 +15,7 @@ export const Theme = ({
   legend,
   tooltip,
   animationDuration,
-}: ThemeProps) => {
+}: ThemeProps<Datum>) => {
   const [, setTheme] = useAtom(themeState)
   const reconcileAxis = (
     thisAxis: typeof axisX | typeof axisY,

--- a/packages/graphique/src/gg/tooltip/Tooltip.tsx
+++ b/packages/graphique/src/gg/tooltip/Tooltip.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react"
 import { useAtom } from "jotai"
 import { tooltipState, TooltipProps } from "../../atoms"
 
-export const Tooltip = ({
+export const Tooltip = <Datum,>({
   keepInParent,
   position,
   xAxis,
@@ -13,7 +13,7 @@ export const Tooltip = ({
   datum,
   dx,
   dy,
-}: TooltipProps) => {
+}: TooltipProps<Datum>) => {
   const [, setTooltip] = useAtom(tooltipState)
 
   useEffect(() => {

--- a/packages/graphique/src/gg/types/Aes.ts
+++ b/packages/graphique/src/gg/types/Aes.ts
@@ -1,5 +1,5 @@
-export type DataValue = (
-  d: any
+export type DataValue<Datum> = (
+  d: Datum
 ) =>
   | number
   | Date
@@ -8,32 +8,32 @@ export type DataValue = (
   | (Date & { valueOf(): number } & string)
   | ({ toString(): string } & string)
 
-export interface Aes {
+export interface Aes<Datum> {
   /** a functional mapping to `data` used to create an **x** scale */
-  x: DataValue
+  x: DataValue<Datum>
   /** a functional mapping to `data` used to create a **y** scale */
-  y?: DataValue
+  y?: DataValue<Datum>
   /** a functional mapping to `data` used to create a **stroke** scale */
-  stroke?: DataValue
+  stroke?: DataValue<Datum>
   /** a functional mapping to `data` used to create a **strokeDasharray** scale */
-  strokeDasharray?: DataValue
+  strokeDasharray?: DataValue<Datum>
   /** a functional mapping to `data` used to create a
    * continuous **size** scale
    *
    * Right now it's only used with `<GeomPoint>` to create a radius scale for points.
    */
-  size?: (d: any) => number | null | undefined
+  size?: (d: Datum) => number | null | undefined
   /** a functional mapping to `data` used to create a **fill** scale */
-  fill?: DataValue
+  fill?: DataValue<Datum>
   /** a functional mapping to `data` used to create
    * distinct groups explicitly (without an associated scale) */
-  group?: DataValue
+  group?: DataValue<Datum>
   /** a functional mapping to `data` used to label tooltips */
-  label?: (d: any) => string | null | undefined
+  label?: (d?: Datum) => string
   /** a functional mapping to `data` used to distinguish
    * individual data points
    *
    * (useful for `<GeomPoint>`)
    * */
-  key?: (d?: any) => string | number
+  key?: (d?: Datum) => string
 }

--- a/packages/graphique/src/gg/types/GG.ts
+++ b/packages/graphique/src/gg/types/GG.ts
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Aes } from './Aes'
 
-export interface RootGGProps {
+export interface RootGGProps<Datum> {
   /** the data used to create the base, an array of objects */
-  data: unknown[]
+  data: Datum[]
   /** the mapping of data characteristics to visual characteristics */
-  aes: Aes
+  aes: Aes<Datum>
   /** the width of the visualization area in pixels (defaults to `550`)
    *
    * Use `isContainerWidth` if you'd like it to be as wide as the parent container.
@@ -27,7 +27,7 @@ export interface RootGGProps {
   children?: ReactNode
 }
 
-export interface GGProps extends RootGGProps {
+export interface GGProps<Datum> extends RootGGProps<Datum> {
   parentWidth?: number
   id?: string
 }

--- a/packages/graphique/src/util/EventArea.tsx
+++ b/packages/graphique/src/util/EventArea.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback, useEffect, useRef, useState } from 'react'
 import { ScaleBand } from 'd3-scale'
 import { Delaunay } from 'd3-delaunay'
-import { useAtom } from 'jotai'
+import { SetStateAction, useAtom } from 'jotai'
 import { pointer } from 'd3-selection'
 import { extent, max, min } from 'd3-array'
 import {
@@ -10,6 +10,7 @@ import {
   xScaleState,
   yScaleState,
   zoomState,
+  TooltipProps,
 } from '../atoms'
 import type { Aes, DataValue, BrushAction } from '../gg'
 import { useGG } from '../gg/GGBase'
@@ -105,7 +106,9 @@ export const EventArea = <Datum,>({
     },
   }
 
-  const [{ datum: ttDatum }, setTooltip] = useAtom(tooltipState)
+  const [{ datum: ttDatum }, setTooltip] = (
+    useAtom<TooltipProps<Datum>, SetStateAction<TooltipProps<Datum>>, void>(tooltipState)
+  )
   const [{ animationDuration, geoms }] = useAtom(themeState)
   const [{ domain: givenYDomain, reverse: reverseY }, setYScale] =
     useAtom(yScaleState)
@@ -167,7 +170,7 @@ export const EventArea = <Datum,>({
     [scales?.xScale, scales?.yScale]
   )
 
-  const delaunayData = useMemo(() => data as [], [data])
+  const delaunayData = useMemo(() => data ?? [], [data])
   const delaunayX = useCallback((v: any) => (x(v) ?? 0) + xAdj, [x, xAdj])
   const delaunayY = useCallback((v: any) => (y(v) ?? 0) + yAdj, [y, yAdj])
 

--- a/packages/graphique/src/util/EventArea.tsx
+++ b/packages/graphique/src/util/EventArea.tsx
@@ -27,29 +27,29 @@ interface StackMidpoint<X, Y> {
   yVal: Y
 }
 
-interface EventAreaProps {
-  x: (d: any) => number | undefined
-  y: (d: any) => number | undefined
+interface EventAreaProps<Datum> {
+  x: (d: Datum) => number | undefined
+  y: (d: Datum) => number | undefined
   group?: 'x' | 'y'
   xAdj?: number
   yAdj?: number
-  onMouseOver?: ({ d, i }: { d: any; i: number[] }) => void
-  onClick?: ({ d, i }: { d: any; i: number[] }) => void
+  onMouseOver?: ({ d, i }: { d: Datum[]; i: number[] }) => void
+  onClick?: ({ d, i }: { d: Datum[]; i: number[] }) => void
   onMouseLeave: () => void
-  onDatumFocus?: (data: any, index: number[]) => void
-  data?: unknown[]
+  onDatumFocus?: (data: Datum[], index: number[]) => void
+  data?: Datum[]
   stackXMidpoints?: StackMidpoint<string | number, string | number>[]
   stackYMidpoints?: StackMidpoint<string | number, string | number>[]
   xBandScale?: ScaleBand<string>
   yBandScale?: ScaleBand<string>
-  aes?: Omit<Aes, 'x'> & {
-    x?: DataValue
-    y0?: DataValue
-    y1?: DataValue
+  aes?: Omit<Aes<Datum>, 'x'> & {
+    x?: DataValue<Datum>
+    y0?: DataValue<Datum>
+    y1?: DataValue<Datum>
   }
   customXExtent?: (number | undefined)[]
   customYExtent?: (number | undefined)[]
-  getYValExtent?: (data: unknown[]) => (number | undefined)[]
+  getYValExtent?: (data: Datum[]) => (number | undefined)[]
   positionKeys?: string
   disabled?: boolean
   fill?: 'x' | 'y'
@@ -60,7 +60,7 @@ interface EventAreaProps {
 
 const BUFFER = 2
 
-export const EventArea = ({
+export const EventArea = <Datum,>({
   x,
   y,
   group,
@@ -85,7 +85,7 @@ export const EventArea = ({
   xBandScale,
   yBandScale,
   fill,
-}: EventAreaProps) => {
+}: EventAreaProps<Datum>) => {
   const { ggState } = useGG() || {}
   const {
     width,
@@ -219,7 +219,7 @@ export const EventArea = ({
         (xd?.xVal ?? 0) + dx + xAdj,
         height - margin.bottom,
       ]),
-      data: xd.data,
+      data: xd.data as Datum[],
     }))
   }, [xDelaunays, scales?.xScale, xBandScale, xAdj, width, margin])
 
@@ -264,7 +264,7 @@ export const EventArea = ({
         width - margin.right,
         (yd.yVal ?? 0) + dy + yAdj,
       ]),
-      data: yd.data,
+      data: yd.data as Datum[],
     }))
   }, [yDelaunays, scales?.yScale, yAdj, width, margin])
 
@@ -567,7 +567,7 @@ export const EventArea = ({
             // skip if the data hasn't changed
             if (ttDatum && x(ttDatum[0]) === left) return
 
-            const groupDatum: unknown[] = []
+            const groupDatum: Datum[] = []
             const groupDatumInd: number[] = []
 
             data.forEach((d, i) => {
@@ -592,9 +592,9 @@ export const EventArea = ({
             }))
           } else if (yGrouped && aes?.y && datumInYRange) {
             // skip if the data hasn't changed
-            if (ttDatum && y(ttDatum[0] === y(datum))) return
+            if (ttDatum && y(ttDatum[0]) === y(datum)) return
 
-            const groupDatum: unknown[] = []
+            const groupDatum: Datum[] = []
             const groupDatumInd: number[] = []
 
             data.forEach((d, i) => {
@@ -714,7 +714,7 @@ export const EventArea = ({
         const datum = data[ind]
 
         if (xGrouped && aes?.x) {
-          const groupDatum: unknown[] = []
+          const groupDatum: Datum[] = []
           const groupDatumInd: number[] = []
 
           data.forEach((d, i) => {
@@ -725,7 +725,7 @@ export const EventArea = ({
           })
           onClick({ d: groupDatum, i: groupDatumInd })
         } else if (yGrouped && aes?.y) {
-          const groupDatum: unknown[] = []
+          const groupDatum: Datum[] = []
           const groupDatumInd: number[] = []
 
           data.forEach((d, i) => {
@@ -737,7 +737,7 @@ export const EventArea = ({
 
           onClick({ d: groupDatum, i: groupDatumInd })
         } else {
-          onClick({ d: datum, i: [ind] })
+          onClick({ d: [datum], i: [ind] })
         }
       }
       return width
@@ -757,7 +757,7 @@ export const EventArea = ({
   )
 
   const handleVoronoiMouseOver = useCallback(
-    (voronoiData: unknown[], i) => {
+    (voronoiData: Datum[], i: number) => {
       if (
         readyToFocusRef.current &&
         voronoiData &&
@@ -765,7 +765,7 @@ export const EventArea = ({
         !isBrushing
       ) {
         const datum = voronoiData[i]
-        const focusedData: unknown[] = []
+        const focusedData: Datum[] = []
         const focusedIndexes: number[] = []
 
         if (xGrouped && aes?.x) {

--- a/packages/graphique/src/util/autoScale.ts
+++ b/packages/graphique/src/util/autoScale.ts
@@ -16,36 +16,36 @@ import {
 import { defineGroupAccessor } from './defineGroupAccessor'
 import { isDate } from './dates'
 
-export interface IScale {
+export interface IScale<Datum> {
   xScale: XYScaleTypes
   yScale: XYScaleTypes
   fillScale?: VisualEncodingTypes
   strokeScale?: VisualEncodingTypes
   strokeDasharrayScale?: VisualEncodingTypes
-  groupAccessor: DataValue | undefined
+  groupAccessor: DataValue<Datum> | undefined
   groups?: string[]
 }
 
-export interface AutoScale extends GGProps {
+export interface AutoScale<Datum> extends GGProps<Datum> {
   scalesState: {
     x: XYScaleProps
     y: XYScaleProps
     hasZeroXBaseLine: boolean
     hasZeroYBaseLine: boolean
-    geomGroupAccessors: DataValue[]
-    y0Aes?: DataValue
-    y1Aes?: DataValue
-    geomAesYs: DataValue[]
-    geomAesStrokes: DataValue[]
-    geomAesFills: DataValue[]
+    geomGroupAccessors: DataValue<Datum>[]
+    y0Aes?: DataValue<Datum>
+    y1Aes?: DataValue<Datum>
+    geomAesYs: DataValue<Datum>[]
+    geomAesStrokes: DataValue<Datum>[]
+    geomAesFills: DataValue<Datum>[]
     fill?: VisualEncodingProps
     stroke?: VisualEncodingProps
     strokeDasharray?: VisualEncodingProps
   }
-  copiedData: unknown[]
+  copiedData: Datum[]
 }
 
-export const autoScale = ({
+export const autoScale = <Datum,>({
   scalesState,
   data,
   copiedData,
@@ -53,7 +53,7 @@ export const autoScale = ({
   width = 500,
   height = 450,
   margin: suppliedMargin,
-}: AutoScale): IScale => {
+}: AutoScale<Datum>): IScale<Datum> => {
   const margin = {
     top: 10,
     right: 20,

--- a/packages/graphique/src/util/defineGroupAccessor.ts
+++ b/packages/graphique/src/util/defineGroupAccessor.ts
@@ -1,6 +1,6 @@
 import type { Aes } from "../gg";
 
-export const defineGroupAccessor = (aes: Aes, allowUndefined = false) => {
+export const defineGroupAccessor = <Datum>(aes: Aes<Datum>, allowUndefined = false) => {
     if (!aes && allowUndefined) return undefined
     return (
         aes?.group ||

--- a/packages/graphique/src/util/widen.ts
+++ b/packages/graphique/src/util/widen.ts
@@ -1,10 +1,10 @@
 import { isDate } from "./dates"
 
-export const widen = (
-  data: unknown[],
-  pivot: (d: unknown) => any,
-  getGroup: (d: unknown) => any,
-  count: (d: unknown) => any
+export const widen = <Datum>(
+  data: Datum[],
+  pivot: (d: Datum) => any,
+  getGroup: (d: Datum) => any,
+  count: (d: Datum) => any
 ) => {
   const pivots = Array.from(new Set(data.map(d => isDate(pivot(d)) ? pivot(d).valueOf() : pivot(d))))
   const groups = Array.from(new Set(data.map(getGroup)))


### PR DESCRIPTION
This introduces a generic `<Datum>` type on most relevant Graphique components, so that:
- `aes` methods can be typed according to the provided `data`
- related data is typed appropriately and more conveniently (e.g. in `Tooltip`s)

this makes autocomplete/intellisense in editors like VSCode much more useful:

<img width="563" alt="image" src="https://github.com/graphiquejs/graphique/assets/2267966/7f1dc0de-925f-4ea1-9d69-6e5e3fa81c6f">

child `Geom`s can also be given a type argument to accomplish the same things at a more local, geom-specific level, for props like `aes` and `onDatumFocus`. e.g.:

```tsx
<GeomPoint<Penguin> aes={{ size: d => d.beakLength }} />
```