### PR TITLE
`onDatumSelection` `data` should have array type

### DIFF
--- a/packages/geom-area/src/geomArea.tsx
+++ b/packages/geom-area/src/geomArea.tsx
@@ -50,7 +50,7 @@ export interface GeomAreaProps<Datum> extends SVGAttributes<SVGPathElement> {
   markerRadius?: number
   markerStroke?: string
   onDatumFocus?: (data: Datum[], index: number[]) => void
-  onDatumSelection?: (data: Datum, index: number[]) => void
+  onDatumSelection?: (data: Datum[], index: number[]) => void
   onExit?: () => void
   fillOpacity?: number
   strokeOpacity?: number
@@ -653,7 +653,7 @@ const GeomArea = <Datum,>({
             }}
             onClick={
               onDatumSelection
-                ? ({ d, i }: { d: any; i: number[] }) => {
+                ? ({ d, i }: { d: Datum[]; i: number[] }) => {
                     onDatumSelection(d, i)
                   }
                 : undefined

--- a/packages/geom-line/src/geomLine.tsx
+++ b/packages/geom-line/src/geomLine.tsx
@@ -48,7 +48,7 @@ export interface LineProps<Datum> extends SVGAttributes<SVGPathElement> {
   focusedStyle?: CSSProperties
   unfocusedStyle?: CSSProperties
   onDatumFocus?: (data: Datum[], index: number[]) => void
-  onDatumSelection?: (data: Datum, index: number[]) => void
+  onDatumSelection?: (data: Datum[], index: number[]) => void
   onExit?: () => void
 }
 
@@ -471,7 +471,7 @@ const GeomLine = <Datum,>({
             }}
             onClick={
               onDatumSelection
-                ? ({ d, i }: { d: any; i: number[] }) => {
+                ? ({ d, i }: { d: Datum[]; i: number[] }) => {
                     onDatumSelection(d, i)
                   }
                 : undefined


### PR DESCRIPTION
fixes a mis-typed parameter in `onDatumSelection` callback for a couple geoms