### PR TITLE
Geom area: fix complex groupings + valid voronoi bounds

### DIFF
--- a/packages/geom-area/src/__tests__/GeomAreaComplexGrouping.test.tsx
+++ b/packages/geom-area/src/__tests__/GeomAreaComplexGrouping.test.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { type Stock } from '@graphique/datasets'
+import {
+  DEFAULT_AREA_PROPS,
+  DEFAULT_GROUP_FILLS,
+  GGArea,
+  NUM_GROUPS,
+  DEFAULT_AES,
+} from './shared'
+import { GeomArea } from '../geomArea'
+
+jest.useFakeTimers()
+
+const NUM_DERIVED_FILLS = 2
+
+describe('area chart complexities with GeomArea', () => {
+  it('renders area chart with combinations of groups/fills', async () => {
+    render(
+      <GGArea
+        {...DEFAULT_AREA_PROPS}
+        aes={{
+          x: DEFAULT_AES.x,
+          y: undefined,
+          group: d => d.symbol,
+          fill: d => String(d.symbol.startsWith('M'))
+        }}
+      >
+        <GeomArea<Stock>
+          aes={{
+            y0: d => d.marketCap - (d.marketCap * 0.1),
+            y1: d => d.marketCap + (d.marketCap * 0.1) 
+          }}
+        />
+      </GGArea>
+    )
+
+    act(() => jest.runAllTimers())
+
+    // exists
+    const chart = screen.queryByTestId('__gg_gg')
+    expect(chart).toBeInTheDocument()
+
+    // area ranges are there
+    const areas = await screen.findAllByTestId('__gg_geom_area')
+    expect(areas).toHaveLength(NUM_GROUPS)
+    
+    // with default fill colors
+    const areaFills = Array.from(new Set(areas.map(a => a.getAttribute('fill'))))
+    const hasSameNumFills = areaFills.length === NUM_DERIVED_FILLS
+    expect(
+      hasSameNumFills &&
+        areaFills.every((fill, i) => fill === DEFAULT_GROUP_FILLS[i])
+    ).toBeTruthy()
+  })
+})

--- a/packages/geom-area/src/geomArea.tsx
+++ b/packages/geom-area/src/geomArea.tsx
@@ -10,14 +10,12 @@ import {
   widen,
   yScaleState,
   zoomState,
-  defineGroupAccessor,
   defaultScheme,
   fillScaleState,
   strokeScaleState,
   VisualEncodingTypes,
   BrushAction,
   AreaPositions,
-  type Aes,
 } from '@graphique/graphique'
 import { Animate } from 'react-move'
 import { easeCubic } from 'd3-ease'
@@ -167,9 +165,9 @@ const GeomArea = <Datum,>({
   const group = useMemo(
     () =>
       geomAes?.group ?? geomAes?.fill
-        ? defineGroupAccessor(geomAes as Aes<Datum>)
+        ? geomAes?.group ?? geomAes?.fill
         : (scales?.groupAccessor ?? (() => '__group')),
-    [geomAes, defineGroupAccessor]
+    [geomAes]
   )
 
   const groups = useMemo(
@@ -418,7 +416,7 @@ const GeomArea = <Datum,>({
           fill: fillColor,
           fillScale: geomFillScale,
           strokeScale: geomStrokeScale,
-          groupAccessor: group,
+          groupAccessor: geomAes?.fill ?? geomAes?.group,
           usableGroups: groups,
           y0,
           y1,

--- a/packages/graphique/src/util/EventArea.tsx
+++ b/packages/graphique/src/util/EventArea.tsx
@@ -256,7 +256,8 @@ export const EventArea = <Datum,>({
   ])
 
   const yVoronois = useMemo(() => {
-    if (!yDelaunays || !isVoronoi) return undefined
+    const isValid = (width - (margin.left + margin.right) > 0)
+    if (!yDelaunays || !isVoronoi || !isValid) return undefined
 
     const dy = (yBandScale?.step?.() ?? 0) / 2
 
@@ -272,7 +273,9 @@ export const EventArea = <Datum,>({
   }, [yDelaunays, scales?.yScale, yAdj, width, margin])
 
   const voronoi = useMemo(() => {
-    if (!isVoronoi) return undefined
+    const isValid = (width - (margin.left + margin.right) > 0)
+      && (height - (margin.bottom + margin.top) > 0)
+    if (!isVoronoi || !isValid) return undefined
 
     return delaunay.voronoi([
       margin.left,
@@ -921,7 +924,7 @@ export const EventArea = <Datum,>({
                 style={{ pointerEvents: 'all' }}
                 d={v.voronoi.renderCell(j)}
                 fill="none"
-                // stroke="tomato"
+                stroke="tomato"
                 onMouseOver={() => handleVoronoiMouseOver(v.data, j)}
               />
             ))}

--- a/packages/graphique/src/util/EventArea.tsx
+++ b/packages/graphique/src/util/EventArea.tsx
@@ -924,7 +924,7 @@ export const EventArea = <Datum,>({
                 style={{ pointerEvents: 'all' }}
                 d={v.voronoi.renderCell(j)}
                 fill="none"
-                stroke="tomato"
+                // stroke="tomato"
                 onMouseOver={() => handleVoronoiMouseOver(v.data, j)}
               />
             ))}


### PR DESCRIPTION
This adjusts the group accessor used in GeomArea to correctly render multiple groupings of areas (e.g. based on `group` and `fill` accessors). It also includes a small change to prevent voronoi diagrams from being generated when there are invalid bounds.